### PR TITLE
G9 Fix: Change `MaxOutstandingBytes` to match client UDP socket buffer size (64kb)

### DIFF
--- a/src/Sanctuary.Gateway/Program.cs
+++ b/src/Sanctuary.Gateway/Program.cs
@@ -81,6 +81,12 @@ builder.ConfigureServices((hostBuilderContext, serviceCollection) =>
             ProtocolName = "CGAPI_527"
         };
 
+        for (int i = 0; i < udpParams.Reliable.Length; i++)
+        {
+            // DO NOT INCREASE; latent client bug when larger than socket buffer size
+            udpParams.Reliable[i].MaxOutstandingBytes = 64 * 1024;
+        }
+
         if (serverOptions.UseCompression)
         {
             udpParams.EncryptMethod[0] = EncryptMethod.UserSupplied;

--- a/src/Sanctuary.UdpLibrary/Configuration/UdpParams.cs
+++ b/src/Sanctuary.UdpLibrary/Configuration/UdpParams.cs
@@ -477,7 +477,7 @@ public class UdpParams
         UserSuppliedEncryptExpansionBytes2 = 0;
 
         Reliable[0].MaxInstandingPackets = 400;
-        Reliable[0].MaxOutstandingBytes = 64 * 1024; // DO NOT INCREASE; latent client bug when larger than socket buffer size
+        Reliable[0].MaxOutstandingBytes = 200 * 1024;
         Reliable[0].MaxOutstandingPackets = 400;
         Reliable[0].OutOfOrder = false;
         Reliable[0].Coalesce = true;

--- a/src/Sanctuary.UdpLibrary/Configuration/UdpParams.cs
+++ b/src/Sanctuary.UdpLibrary/Configuration/UdpParams.cs
@@ -477,7 +477,7 @@ public class UdpParams
         UserSuppliedEncryptExpansionBytes2 = 0;
 
         Reliable[0].MaxInstandingPackets = 400;
-        Reliable[0].MaxOutstandingBytes = 200 * 1024;
+        Reliable[0].MaxOutstandingBytes = 64 * 1024; // DO NOT INCREASE; latent client bug when larger than socket buffer size
         Reliable[0].MaxOutstandingPackets = 400;
         Reliable[0].OutOfOrder = false;
         Reliable[0].Coalesce = true;


### PR DESCRIPTION
Some players are hitting occasional (or persistent) G9 errors when connecting to the Gateway server.

I dumped the callstack at the error dispatch site in the client and discovered that this error is being triggered by corrupted fragment-reassembler state during reassembly of the large player data blob received from the server. I was unable to determine the corruption mechanism in the client, but I did observe that this issue only happened to me on the public server and not my identical localhost copy.

I added a proxy that artificially increases RTT ("lag switch") between my client and the localhost server and was able to get a repro. While grasping at straws, I noticed that my kernel counter was reporting a lot of dropped UDP packets. I then discovered that **increasing the client's UDP socket buffer size in the kernel solved the issue**. I'm not sure why this is the case; UDP socket buffer overflow should just result in dropped packets, which the SoE protocol is supposed to handle on the reliable channel. Evidently, there is an issue with the client's implementation that only manifests when the channel is super backed up due to high RTT.

Since we want to keep the client binary pristine, we can solve this on the server end instead: ensure the amount of bytes on the wire is never larger than the client's 64kb buffer. This guarantees that a socket buffer overflow cannot happen, thus no packets get dropped and the client bug is not triggered.