### PR TITLE
Fix incorrect calculation of reliable packet IDs under backpressure (real fix for packet corruption / G9)

### DIFF
--- a/src/Sanctuary.Gateway/Program.cs
+++ b/src/Sanctuary.Gateway/Program.cs
@@ -81,12 +81,6 @@ builder.ConfigureServices((hostBuilderContext, serviceCollection) =>
             ProtocolName = "CGAPI_527"
         };
 
-        for (int i = 0; i < udpParams.Reliable.Length; i++)
-        {
-            // DO NOT INCREASE; latent client bug when larger than socket buffer size
-            udpParams.Reliable[i].MaxOutstandingBytes = 64 * 1024;
-        }
-
         if (serverOptions.UseCompression)
         {
             udpParams.EncryptMethod[0] = EncryptMethod.UserSupplied;

--- a/src/Sanctuary.UdpLibrary/Internal/UdpReliableChannel.cs
+++ b/src/Sanctuary.UdpLibrary/Internal/UdpReliableChannel.cs
@@ -63,6 +63,7 @@ internal class UdpReliableChannel
         public LogicalPacket? Parent;
         public int? DataPtr;
         public int DataLen;
+        public long ReliableId;
     }
 
     private struct IncomingQueueEntry
@@ -461,7 +462,12 @@ internal class UdpReliableChannel
                             // if we have queue space
                             if (readyPtr < readyEnd)
                             {
-                                ReadyQueue[readyPtr++] = entry;
+                                ReadyQueue[readyPtr] = entry;
+                                // remember this entry's true reliable id (its ring position),
+                                // mirroring the original library which stored pointers into the
+                                // physical-packet ring and recovered the id from the offset.
+                                ReadyQueue[readyPtr].ReliableId = i;
+                                readyPtr++;
                             }
                             else
                             {
@@ -513,9 +519,14 @@ internal class UdpReliableChannel
                     if (entry.DataPtr.Value != 0 || entry.DataLen != entry.Parent.GetDataLen())
                         fragment = true;
 
-                    // we can calculate what our reliableId should be based on our position in the array
-                    // need to handle the case where we wrap around the end of the array
-                    var reliableId = ReliableOutgoingPendingId + (readyWalk - 1);
+                    // use the entry's true reliable id (captured from its ring position when it
+                    // was queued). Deriving the id from the ready-queue index instead is only
+                    // correct when the ready queue is a gapless prefix of the outstanding window;
+                    // under partial resends the queue is compacted, which would otherwise stamp the
+                    // payload with the wrong sequence number and duplicate data under a fresh id.
+                    // That causes a correctly-fired G9 (corrupted packet) error from the client
+                    // whenever there's enough backpressure on the wire to cause many retransmissions.
+                    var reliableId = entry.ReliableId;
 
                     // prep the actual packet and send it
                     buf[0] = 0;

--- a/src/Sanctuary.UdpLibrary/Internal/UdpReliableChannel.cs
+++ b/src/Sanctuary.UdpLibrary/Internal/UdpReliableChannel.cs
@@ -524,8 +524,6 @@ internal class UdpReliableChannel
                     // correct when the ready queue is a gapless prefix of the outstanding window;
                     // under partial resends the queue is compacted, which would otherwise stamp the
                     // payload with the wrong sequence number and duplicate data under a fresh id.
-                    // That causes a correctly-fired G9 (corrupted packet) error from the client
-                    // whenever there's enough backpressure on the wire to cause many retransmissions.
                     var reliableId = entry.ReliableId;
 
                     // prep the actual packet and send it


### PR DESCRIPTION
So previously we had discovered that the G9 error was mitigated by limiting how many outstanding bytes can be over the wire at a time: #16 

I wanted to understand the "client bug" a little more, but I reverse-engineered the entire fragment reassembly loop and could not see any logic errors at all. So I went back to my packet captures and noticed that **retransmitted fragments with identical payloads were being sent with *new* RIDs instead of their original ones.** This causes the client to slot the fragments in the wrong spots when reconstructing the big, and so the client detects that the packet is corrupt and fires off G9.

This also explains why G9 is so easy to repro with backpressure on the wire: this scenario only happens with retransmission. Anything that can delay processing of packets can cause increased retransmission rate, including but not limited to:
- high ping to the server
- compatibility layers like Wine on Linux or MacOS
- old devices with slow networking stacks
- **UDP buffers that are smaller than the wire capacity** (what I targeted in my mitigation PR)

Ultimately this pointed to the real server bug: **the RID calculation is done in the wrong place.** It should be done in the ring buffer and recorded for later use, so that the same RID is used on retransmission under wraparound conditions. [This is what the C++ implementation of the SoE protocol does, and it lines up with what the client expects](https://github.com/SWG-Source/src/blob/master/external/3rd/library/soePlatform/ChatAPI/utils/UdpLibrary/UdpReliableChannel.cpp).

Fix was validated by running the server with the RID change under the old UDP parameters. 20 iterations, zero G9 errors. I also did another packet capture to confirm the RIDs are consistent under heavy retransmission.

I was told there was a desire to keep UDP parameters unchanged, so I reverted the changes from my last PR to keep the implementation true to the original protocol.

