### PR TITLE
Track friend requests in state + harden friend request validation

### DIFF
--- a/src/Sanctuary.Core/Collections/ConcurrentSet.cs
+++ b/src/Sanctuary.Core/Collections/ConcurrentSet.cs
@@ -16,11 +16,11 @@ public class ConcurrentSet<T> : IEnumerable<T> where T : notnull
         _dictionary = new ConcurrentDictionary<T, byte>();
     }
 
-    public bool Add(T item) => _dictionary.TryAdd(item, 0);
+    public bool TryAdd(T item) => _dictionary.TryAdd(item, 0);
 
     public bool Contains(T item) => _dictionary.ContainsKey(item);
 
-    public bool Remove(T item) => _dictionary.TryRemove(item, out _);
+    public bool TryRemove(T item) => _dictionary.TryRemove(item, out _);
 
     public void Clear() => _dictionary.Clear();
 

--- a/src/Sanctuary.Core/Collections/ConcurrentSet.cs
+++ b/src/Sanctuary.Core/Collections/ConcurrentSet.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Sanctuary.Core.Collections;
+
+public class ConcurrentSet<T> : IEnumerable<T>
+{
+    private readonly ConcurrentDictionary<T, byte> _dictionary;
+
+    /// <summary>
+    /// Initializes an instance of the ConcurrentSet class.
+    /// </summary>
+    public ConcurrentSet()
+    {
+        _dictionary = new ConcurrentDictionary<T, byte>();
+    }
+
+    public bool Add(T item) => _dictionary.TryAdd(item, 0);
+
+    public bool Contains(T item) => _dictionary.ContainsKey(item);
+
+    public bool Remove(T item) => _dictionary.TryRemove(item, out _);
+
+    public void Clear() => _dictionary.Clear();
+
+    public int Count => _dictionary.Count;
+
+    public bool IsEmpty => _dictionary.IsEmpty;
+
+    public IEnumerator<T> GetEnumerator() => _dictionary.Keys.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/Sanctuary.Core/Collections/ConcurrentSet.cs
+++ b/src/Sanctuary.Core/Collections/ConcurrentSet.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Sanctuary.Core.Collections;
 
-public class ConcurrentSet<T> : IEnumerable<T>
+public class ConcurrentSet<T> : IEnumerable<T> where T : notnull
 {
     private readonly ConcurrentDictionary<T, byte> _dictionary;
 

--- a/src/Sanctuary.Game/Entities/Player.cs
+++ b/src/Sanctuary.Game/Entities/Player.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 
+using Sanctuary.Core.Collections;
 using Sanctuary.Core.IO;
 using Sanctuary.Game.Interactions;
 using Sanctuary.Game.Zones;
@@ -42,6 +43,8 @@ public sealed class Player : ClientPcData, IEntity
 
     public List<FriendData> Friends { get; set; } = [];
     public List<IgnoreData> Ignores { get; set; } = [];
+
+    public ConcurrentSet<ulong> IncomingFriendRequests { get; } = [];
 
     public ConcurrentDictionary<ChatChannel, bool> ChatChannelStatus { get; set; } = [];
 

--- a/src/Sanctuary.Game/Interactions/AddFriendInteraction.cs
+++ b/src/Sanctuary.Game/Interactions/AddFriendInteraction.cs
@@ -28,6 +28,9 @@ public class AddFriendInteraction : IInteraction
         if (otherPlayer.Ignores.Any(x => x.Guid == player.Guid))
             return;
 
+        if (otherPlayer.Friends.Any(x => x.Guid == player.Guid))
+            return;
+
         otherPlayer.IncomingFriendRequests.Add(player.Guid);
 
         var friendMessagePacket = new FriendMessagePacket();

--- a/src/Sanctuary.Game/Interactions/AddFriendInteraction.cs
+++ b/src/Sanctuary.Game/Interactions/AddFriendInteraction.cs
@@ -25,6 +25,8 @@ public class AddFriendInteraction : IInteraction
         if (otherPlayer.Ignores.Any(x => x.Guid == player.Guid))
             return;
 
+        otherPlayer.IncomingFriendRequests.Add(player.Guid);
+
         var friendMessagePacket = new FriendMessagePacket();
 
         friendMessagePacket.Type = FriendMessageType.FriendAddRequested;

--- a/src/Sanctuary.Game/Interactions/AddFriendInteraction.cs
+++ b/src/Sanctuary.Game/Interactions/AddFriendInteraction.cs
@@ -31,7 +31,7 @@ public class AddFriendInteraction : IInteraction
         if (otherPlayer.Friends.Any(x => x.Guid == player.Guid))
             return;
 
-        otherPlayer.IncomingFriendRequests.Add(player.Guid);
+        otherPlayer.IncomingFriendRequests.TryAdd(player.Guid);
 
         var friendMessagePacket = new FriendMessagePacket();
 

--- a/src/Sanctuary.Game/Interactions/AddFriendInteraction.cs
+++ b/src/Sanctuary.Game/Interactions/AddFriendInteraction.cs
@@ -22,6 +22,9 @@ public class AddFriendInteraction : IInteraction
         if (other is not Player otherPlayer)
             return;
 
+        if (otherPlayer.Guid == player.Guid)
+            return;
+
         if (otherPlayer.Ignores.Any(x => x.Guid == player.Guid))
             return;
 

--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketAddFriendRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketAddFriendRequestHandler.cs
@@ -53,6 +53,8 @@ public static class CommandPacketAddFriendRequestHandler
         if (player.Ignores.Any(x => x.Guid == connection.Player.Guid))
             return true;
 
+        player.IncomingFriendRequests.Add(connection.Player.Guid);
+
         var friendMessagePacket = new FriendMessagePacket();
 
         friendMessagePacket.Type = FriendMessageType.FriendAddRequested;

--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketAddFriendRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketAddFriendRequestHandler.cs
@@ -59,7 +59,7 @@ public static class CommandPacketAddFriendRequestHandler
         if (player.Friends.Any(x => x.Guid == connection.Player.Guid))
             return true;
 
-        player.IncomingFriendRequests.Add(connection.Player.Guid);
+        player.IncomingFriendRequests.TryAdd(connection.Player.Guid);
 
         var friendMessagePacket = new FriendMessagePacket();
 

--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketAddFriendRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketAddFriendRequestHandler.cs
@@ -50,6 +50,9 @@ public static class CommandPacketAddFriendRequestHandler
         if (!_zoneManager.TryGetPlayer(GuidHelper.GetPlayerGuid(dbCharacter.Id), out var player))
             return true;
 
+        if (player.Guid == connection.Player.Guid)
+            return true;
+
         if (player.Ignores.Any(x => x.Guid == connection.Player.Guid))
             return true;
 

--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketAddFriendRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketAddFriendRequestHandler.cs
@@ -56,6 +56,9 @@ public static class CommandPacketAddFriendRequestHandler
         if (player.Ignores.Any(x => x.Guid == connection.Player.Guid))
             return true;
 
+        if (player.Friends.Any(x => x.Guid == connection.Player.Guid))
+            return true;
+
         player.IncomingFriendRequests.Add(connection.Player.Guid);
 
         var friendMessagePacket = new FriendMessagePacket();

--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketConfirmFriendResponseHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketConfirmFriendResponseHandler.cs
@@ -43,7 +43,7 @@ public static class CommandPacketConfirmFriendResponseHandler
 
         _logger.LogTrace("Received {name} packet. ( {packet} )", nameof(CommandPacketConfirmFriendResponse), packet);
 
-        if (!connection.Player.IncomingFriendRequests.Remove(packet.Guid))
+        if (!connection.Player.IncomingFriendRequests.TryRemove(packet.Guid))
             return true;
 
         if (!_zoneManager.TryGetPlayer(packet.Guid, out var player))

--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketConfirmFriendResponseHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketConfirmFriendResponseHandler.cs
@@ -43,6 +43,9 @@ public static class CommandPacketConfirmFriendResponseHandler
 
         _logger.LogTrace("Received {name} packet. ( {packet} )", nameof(CommandPacketConfirmFriendResponse), packet);
 
+        if (!connection.Player.IncomingFriendRequests.Remove(packet.Guid))
+            return true;
+
         if (!_zoneManager.TryGetPlayer(packet.Guid, out var player))
             return true;
 


### PR DESCRIPTION
Few improvements related to friendships:
- Track friend requests in state
  - This fixes a vulnerability where crafted CommandPacketConfirmFriend payloads can force-create friendships without consent from the target player.
  - I added a ConcurrentSet type for this to keep it pretty.
    - Wasn't sure if it needed to be concurrent-- as it looks like all friend stuff happens on one thread-- but better safe than sorry. I also noticed a `FriendAddRequestTimedOut` message which makes it sound like we may one day need to expire them from the world ticker. I'm not comfortable enough to mess with that yet, though.
-  Prohibit sending a friend request to yourself (fixes #10)
   - The client tries to prevent you from sending the request packet out to yourself, but it only checks against name, so a name change would allow it => cause a crash when it reaches the DB.
   - Now we validate in the friend request handlers that the target player ID is not the sending player's ID. Since we track this in state, keeping the validation scoped to the request side is enough.
- Prohibit sending a friend request to someone you're already friends with
  - The client probably blocks this as well-- I didn't test it personally-- but I'm pretty sure a crafted packet could cause a similar DB crash to the name change case, since it would be a duplicate record.