### PR TITLE
Fix coin store list jumping to top after purchase

### DIFF
--- a/src/Sanctuary.Gateway/Handlers/BaseCoinStorePacket/CoinStoreSellToClientRequestPacketHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCoinStorePacket/CoinStoreSellToClientRequestPacketHandler.cs
@@ -177,6 +177,8 @@ public static class CoinStoreSellToClientRequestPacketHandler
 
             clientItem.Serialize(writer);
 
+            clientItemDefinition.Serialize(writer);
+
             var clientUpdatePacketItemAdd = new ClientUpdatePacketItemAdd();
 
             clientUpdatePacketItemAdd.Payload = writer.Buffer;

--- a/src/Sanctuary.Gateway/Handlers/PacketBaseInGamePurchase/PacketInGamePurchasePlaceOrderPacketHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketBaseInGamePurchase/PacketInGamePurchasePlaceOrderPacketHandler.cs
@@ -179,6 +179,8 @@ public static class PacketInGamePurchasePlaceOrderPacketHandler
 
                     clientItem.Serialize(writer);
 
+                    clientItemDefinition.Serialize(writer);
+
                     var clientUpdatePacketItemAdd = new ClientUpdatePacketItemAdd();
 
                     clientUpdatePacketItemAdd.Payload = writer.Buffer;


### PR DESCRIPTION
The ClientUpdatePacketItemAdd handler in the game client deserializes both a ClientItem and a ClientItemDefinition from the same packet payload. The server was only writing the ClientItem data, causing the client to read garbage as a malformed item definition. This triggered a global item definition update broadcast that the coin store UI listened to, causing the entire shop list to refresh and reset selection to the top.

**Change:** Added one line \clientItemDefinition.Serialize(writer);\ to serialize the full item definition into the ItemAdd packet payload, so the client receives valid definition data and the coin store does not trigger a full list refresh.