### PR TITLE
Fix possible player name overflow in DB + crash on character deletion due to FK constraints

### DIFF
--- a/src/Sanctuary.Database.MySql/Configuration/DbCharacterConfiguration.cs
+++ b/src/Sanctuary.Database.MySql/Configuration/DbCharacterConfiguration.cs
@@ -16,7 +16,7 @@ public sealed class DbCharacterConfiguration : IEntityTypeConfiguration<DbCharac
 
         builder.Property(c => c.FirstName).IsRequired().HasMaxLength(16);
         builder.Property(c => c.LastName).IsRequired(false).HasMaxLength(16);
-        builder.Property(c => c.FullName).HasMaxLength(32).HasComputedColumnSql($"CONCAT_WS(' ', `{nameof(DbCharacter.FirstName)}`, NULLIF(`{nameof(DbCharacter.LastName)}`, ''))", true);
+        builder.Property(c => c.FullName).HasMaxLength(33).HasComputedColumnSql($"CONCAT_WS(' ', `{nameof(DbCharacter.FirstName)}`, NULLIF(`{nameof(DbCharacter.LastName)}`, ''))", true);
 
         builder.Property(c => c.Model).IsRequired();
 

--- a/src/Sanctuary.Database.MySql/Migrations/20260706154141_WidenCharacterFullName.Designer.cs
+++ b/src/Sanctuary.Database.MySql/Migrations/20260706154141_WidenCharacterFullName.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sanctuary.Database;
 
@@ -11,9 +12,11 @@ using Sanctuary.Database;
 namespace Sanctuary.Database.MySql.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20260706154141_WidenCharacterFullName")]
+    partial class WidenCharacterFullName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Sanctuary.Database.MySql/Migrations/20260706154141_WidenCharacterFullName.cs
+++ b/src/Sanctuary.Database.MySql/Migrations/20260706154141_WidenCharacterFullName.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sanctuary.Database.MySql.Migrations
+{
+    /// <inheritdoc />
+    public partial class WidenCharacterFullName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "FullName",
+                table: "Characters",
+                type: "varchar(33)",
+                maxLength: 33,
+                nullable: true,
+                computedColumnSql: "CONCAT_WS(' ', `FirstName`, NULLIF(`LastName`, ''))",
+                stored: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(32)",
+                oldMaxLength: 32,
+                oldNullable: true,
+                oldComputedColumnSql: "CONCAT_WS(' ', `FirstName`, NULLIF(`LastName`, ''))",
+                oldStored: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "FullName",
+                table: "Characters",
+                type: "varchar(32)",
+                maxLength: 32,
+                nullable: true,
+                computedColumnSql: "CONCAT_WS(' ', `FirstName`, NULLIF(`LastName`, ''))",
+                stored: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(33)",
+                oldMaxLength: 33,
+                oldNullable: true,
+                oldComputedColumnSql: "CONCAT_WS(' ', `FirstName`, NULLIF(`LastName`, ''))",
+                oldStored: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/src/Sanctuary.Login/Handlers/CharacterDeleteRequestHandler.cs
+++ b/src/Sanctuary.Login/Handlers/CharacterDeleteRequestHandler.cs
@@ -60,13 +60,25 @@ public static class CharacterDeleteRequestHandler
             return true;
         }
 
-        dbContext.Remove(character);
-
-        if (dbContext.SaveChanges() <= 0)
+        try
         {
+            // Delete references first to avoid foreign key constraint violations.
+            dbContext.Friends.Where(f => f.FriendCharacterId == character.Id).ExecuteDelete();
+            dbContext.Ignores.Where(i => i.IgnoreCharacterId == character.Id).ExecuteDelete();
+
+            dbContext.Remove(character);
+
+            dbContext.SaveChanges();
+        }
+        catch (DbUpdateException ex)
+        {
+            _logger.LogError(ex, "Failed to delete character {CharacterId}.", character.Id);
+
             characterDeleteReply.Status = 2;
 
             connection.Send(characterDeleteReply);
+
+            return true;
         }
 
         characterDeleteReply.Status = 1;

--- a/src/Sanctuary.Login/Handlers/CharacterDeleteRequestHandler.cs
+++ b/src/Sanctuary.Login/Handlers/CharacterDeleteRequestHandler.cs
@@ -63,12 +63,21 @@ public static class CharacterDeleteRequestHandler
         try
         {
             // Delete references first to avoid foreign key constraint violations.
-            dbContext.Friends.Where(f => f.FriendCharacterId == character.Id).ExecuteDelete();
-            dbContext.Ignores.Where(i => i.IgnoreCharacterId == character.Id).ExecuteDelete();
+            var friends = dbContext.Friends.Where(f => f.FriendCharacterId == character.Id);
+            var ignores = dbContext.Ignores.Where(i => i.IgnoreCharacterId == character.Id);
 
+            dbContext.Friends.RemoveRange(friends);
+            dbContext.Ignores.RemoveRange(ignores);
             dbContext.Remove(character);
 
-            dbContext.SaveChanges();
+            if (dbContext.SaveChanges() == 0)
+            {
+                characterDeleteReply.Status = 2;
+
+                connection.Send(characterDeleteReply);
+
+                return true;
+            }
         }
         catch (DbUpdateException ex)
         {


### PR DESCRIPTION
Two distinct fixes:
- Max player name length = max firstname + space + max lastname = 16 + 1 + 16 = **33**, not 32, so player names can currently overflow. Fixed the max length and added a migration for it.
- Currently, server crashes if you delete a character that is friends with other characters.
  - The Friend/Ignore records are not deleted on cascade due to the way the tables are setup, but that means there would be records with stale foreign keys, so the delete operation fails.
  - Since the delete op is not surrounded with try/catch, this throws and crashes the server.
  - Fix is two-fold: manually delete the friend/ignore records first, and then surround with try/catch so the server doesn't go down under a failure.
    - Bonus: an early return was missing, so under failure a success result was stored. Fixed.