### PR TITLE
Fix broken dockerfile builds

### DIFF
--- a/src/Docker/Sanctuary.Login.dockerfile
+++ b/src/Docker/Sanctuary.Login.dockerfile
@@ -10,7 +10,6 @@ COPY . /src
 RUN dotnet build "Sanctuary.Login/Sanctuary.Login.csproj" -c $BUILD_CONFIGURATION
 RUN dotnet build "Sanctuary.Database.MySql/Sanctuary.Database.MySql.csproj" -c $BUILD_CONFIGURATION
 RUN dotnet build "Sanctuary.Database.SqLite/Sanctuary.Database.Sqlite.csproj" -c $BUILD_CONFIGURATION
-RUN dotnet build "Sanctuary.Database.SqlServer/Sanctuary.Database.SqlServer.csproj" -c $BUILD_CONFIGURATION
 
 FROM base AS final
 ARG BUILD_CONFIGURATION=Release

--- a/src/Docker/Sanctuary.WebAPI.dockerfile
+++ b/src/Docker/Sanctuary.WebAPI.dockerfile
@@ -1,12 +1,12 @@
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 WORKDIR /app
-EXPOSE 20260
+EXPOSE 20040
 
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY . /src
-RUN dotnet build "Sanctuary.Gateway/Sanctuary.Gateway.csproj" -c $BUILD_CONFIGURATION
+RUN dotnet build "Sanctuary.WebAPI/Sanctuary.WebAPI.csproj" -c $BUILD_CONFIGURATION
 RUN dotnet build "Sanctuary.Database.MySql/Sanctuary.Database.MySql.csproj" -c $BUILD_CONFIGURATION
 RUN dotnet build "Sanctuary.Database.SqLite/Sanctuary.Database.Sqlite.csproj" -c $BUILD_CONFIGURATION
 
@@ -14,4 +14,4 @@ FROM base AS final
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /app
 COPY --from=build /src/**/bin/$BUILD_CONFIGURATION .
-ENTRYPOINT ["dotnet", "Sanctuary.Gateway.dll"]
+ENTRYPOINT ["dotnet", "Sanctuary.WebAPI.dll"]


### PR DESCRIPTION
Currently, the dockerfiles reference a non-existent "Sanctuary.Database.SqlServer" project. This breaks the docker build. Easy fix, pull them out; Docker deployment still works fine.

Also added a dockerfile for the WebAPI project for convenience.