### PR TITLE
Fix 100% CPU usage for login + gateway servers (main busyloop)

### DIFF
--- a/src/Sanctuary.Gateway/GatewayService.cs
+++ b/src/Sanctuary.Gateway/GatewayService.cs
@@ -126,8 +126,12 @@ public class GatewayService : BackgroundService
         // Main server loop.
         while (!cancellationToken.IsCancellationRequested && clientConnection.Status != Status.Disconnected)
         {
-            _server.GiveTime();
-            _client.GiveTime();
+            var hadData = false;
+            hadData |= _server.GiveTime();
+            hadData |= _client.GiveTime();
+
+            if (!hadData)
+                Thread.Sleep(1);
         }
 
         return Task.CompletedTask;

--- a/src/Sanctuary.Login/LoginService.cs
+++ b/src/Sanctuary.Login/LoginService.cs
@@ -74,8 +74,12 @@ public class LoginService : BackgroundService
         // Main server loop.
         while (!cancellationToken.IsCancellationRequested)
         {
-            _loginServer.GiveTime();
-            _gatewayServer.GiveTime();
+            var hadData = false;
+            hadData |= _loginServer.GiveTime();
+            hadData |= _gatewayServer.GiveTime();
+
+            if (!hadData)
+                Thread.Sleep(1);
         }
 
         return Task.CompletedTask;


### PR DESCRIPTION
Main loop in both the login and gateway servers is not sleeping, so both cause 100% CPU usage. Easy fix is to just give the thread a chance to sleep if there's nothing to process.