### PR TITLE
Replace hardcoded safe teleport with nearest warpstone

### DIFF
--- a/src/Sanctuary.Gateway/Handlers/PacketZoneSafeTeleportRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketZoneSafeTeleportRequestHandler.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Linq;
 using System.Numerics;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
+using Sanctuary.Game;
 using Sanctuary.Packet;
+using Sanctuary.Packet.Common;
 using Sanctuary.Packet.Common.Attributes;
 
 namespace Sanctuary.Gateway.Handlers;
@@ -13,11 +16,14 @@ namespace Sanctuary.Gateway.Handlers;
 public static class PacketZoneSafeTeleportRequestHandler
 {
     private static ILogger _logger = null!;
+    private static IResourceManager _resourceManager = null!;
 
     public static void ConfigureServices(IServiceProvider serviceProvider)
     {
         var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
         _logger = loggerFactory.CreateLogger(nameof(PacketZoneSafeTeleportRequestHandler));
+
+        _resourceManager = serviceProvider.GetRequiredService<IResourceManager>();
     }
 
     public static bool HandlePacket(GatewayConnection connection, Span<byte> data)
@@ -30,8 +36,19 @@ public static class PacketZoneSafeTeleportRequestHandler
 
         _logger.LogTrace("Received {name} packet. ( {packet} )", nameof(PacketZoneSafeTeleportRequest), packet);
 
-        var position = new Vector4(-1414.636f, -27.631f, 351.567f, 1f);
-        var rotation = new Quaternion(0f, 0f, 0f, 0f);
+        var pointOfInterest = FindNearestSafePointOfInterest(connection.Player.Position);
+
+        if (pointOfInterest is null)
+        {
+            _logger.LogWarning("No safe teleport destination found for player {guid}.", connection.Player.Guid);
+            return true;
+        }
+
+        var rotationX = MathF.Cos(pointOfInterest.Heading);
+        var rotationZ = MathF.Sin(pointOfInterest.Heading);
+
+        var position = pointOfInterest.SpawnPosition;
+        var rotation = new Quaternion(rotationZ, 0f, rotationX, 0f);
 
         connection.Player.Mount?.UpdatePosition(position, rotation);
         connection.Player.UpdatePosition(position, rotation);
@@ -46,5 +63,34 @@ public static class PacketZoneSafeTeleportRequestHandler
         connection.SendTunneled(clientUpdatePacketUpdateLocation);
 
         return true;
+    }
+
+    private static PointOfInterestDefinition? FindNearestSafePointOfInterest(Vector4 playerPosition)
+    {
+        var hubPointsOfInterest = _resourceManager.PointOfInterests.Values
+            .Where(x => x.NotificationType == 7)
+            .ToList();
+
+        var candidates = hubPointsOfInterest.Count > 0
+            ? hubPointsOfInterest
+            : _resourceManager.PointOfInterests.Values.ToList();
+
+        PointOfInterestDefinition? nearest = null;
+        var nearestDistance = float.MaxValue;
+
+        foreach (var pointOfInterest in candidates)
+        {
+            var dx = playerPosition.X - pointOfInterest.Position.X;
+            var dz = playerPosition.Z - pointOfInterest.Position.Z;
+            var distance = dx * dx + dz * dz;
+
+            if (distance >= nearestDistance)
+                continue;
+
+            nearestDistance = distance;
+            nearest = pointOfInterest;
+        }
+
+        return nearest;
     }
 }

--- a/src/Sanctuary.Gateway/Handlers/PacketZoneSafeTeleportRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketZoneSafeTeleportRequestHandler.cs
@@ -68,7 +68,7 @@ public static class PacketZoneSafeTeleportRequestHandler
     private static PointOfInterestDefinition? FindNearestSafePointOfInterest(Vector4 playerPosition)
     {
         var hubPointsOfInterest = _resourceManager.PointOfInterests.Values
-            .Where(x => x.NotificationType == 7)
+            .Where(x => x.NotificationType == PointOfInterestNotificationType.ZoneHub)
             .ToList();
 
         var candidates = hubPointsOfInterest.Count > 0

--- a/src/Sanctuary.Packet.Common/PointOfInterestNotificationType.cs
+++ b/src/Sanctuary.Packet.Common/PointOfInterestNotificationType.cs
@@ -1,0 +1,9 @@
+﻿namespace Sanctuary.Packet.Common;
+
+public static class PointOfInterestNotificationType
+{
+    public const int Dungeon = 3;   // dungeon entrances
+    public const int Local = 6;     // farms, minigames etc..
+    public const int ZoneHub = 7;   // main zone's
+    public const int Ruins = 10;    // sunstone precursor ruins
+}


### PR DESCRIPTION
Safe teleport no longer sends players to hardcoded sanctuary coordinates. The handler picks the nearest zone POI (NotificationType == 7) from PointOfInterests.json based on the player’s X/Z position, then teleports to that POI’s spawnpostion.

Make sure u merge this one first before [merging this one](https://github.com/Open-Source-Free-Realms/Sanctuary/pull/28)