### PR TITLE
Fix ActiveProfile crash on invalid profile ID and fix double sending guid 

### DIFF
--- a/src/Sanctuary.Game/Entities/Player.cs
+++ b/src/Sanctuary.Game/Entities/Player.cs
@@ -36,7 +36,8 @@ public sealed class Player : ClientPcData, IEntity
     public int ChatBubbleBackgroundColor { get; set; }
     public int ChatBubbleSize { get; set; }
 
-    public ClientPcProfile ActiveProfile => Profiles.Single(x => x.Id == ActiveProfileId);
+    public ClientPcProfile ActiveProfile =>
+        Profiles.FirstOrDefault(x => x.Id == ActiveProfileId) ?? Profiles.First();
 
     public Mount? Mount { get; set; }
 

--- a/src/Sanctuary.Gateway/GatewayConnection.cs
+++ b/src/Sanctuary.Gateway/GatewayConnection.cs
@@ -295,6 +295,22 @@ public class GatewayConnection : UdpConnection
             }
         }
 
+        if (Player.Profiles.Count == 0)
+        {
+            _logger.LogError("Character {id} has no valid profiles.", dbCharacter.Id);
+            return false;
+        }
+
+        if (!Player.Profiles.Any(x => x.Id == dbCharacter.ActiveProfileId))
+        {
+            _logger.LogWarning(
+                "Character {id} has invalid ActiveProfileId {profileId}; using first profile.",
+                dbCharacter.Id,
+                dbCharacter.ActiveProfileId);
+
+            dbCharacter.ActiveProfileId = Player.Profiles[0].Id;
+        }
+
         Player.ActiveProfileId = dbCharacter.ActiveProfileId;
 
         foreach (var dbItem in dbCharacter.Items)

--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketRemoveFriendRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketRemoveFriendRequestHandler.cs
@@ -72,7 +72,7 @@ public static class CommandPacketRemoveFriendRequestHandler
 
         connection.Player.SendTunneled(new FriendRemovePacket
         {
-            Guid = GuidHelper.GetPlayerGuid(dbCharacterToRemoveGuid)
+            Guid = dbCharacterToRemoveGuid
         });
 
         if (_zoneManager.TryGetPlayer(dbCharacterToRemoveGuid, out var player))


### PR DESCRIPTION
ActiveProfile used ```Profiles.Single(...)```. If the ```ActiveProfileId``` in the database does not match a loaded profile (due to corrupted data, a deleted profile, or a resource mismatch), this throws an ```InvalidOperationException```often occurring during login, friend-related operations, or profile switching.