### PR TITLE
Fix local mount visibility sending RiderGuid 0 in AddNpc

### DIFF
--- a/src/Sanctuary.Game/Entities/Player.cs
+++ b/src/Sanctuary.Game/Entities/Player.cs
@@ -263,6 +263,9 @@ public sealed class Player : ClientPcData, IEntity
         {
             var playerUpdatePacketAddNpc = npc.GetAddNpcPacket();
 
+            if (npc is Mount mount && mount.Rider.Guid == Guid)
+                playerUpdatePacketAddNpc.RiderGuid = 0;
+
             SendTunneled(playerUpdatePacketAddNpc);
         }
 


### PR DESCRIPTION
On mount spawn, ```AddNpc``` included the local player's GUID as RiderGuid. The client looks up that rider in the world entity list and logs an error, the actual mount coupling is handled by ```PacketMountResponse```. For your own mount, we set RiderGuid to 0 in AddNpc so only the mount model spawns and MountResponse attaches the rider. I dont know if this was caused by a pull request but i saw it in the logs.