### PR TITLE
ignore functionality improvements

### DIFF
--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketIgnoreRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketIgnoreRequestHandler.cs
@@ -9,10 +9,10 @@ using Sanctuary.Core.Helpers;
 using Sanctuary.Database;
 using Sanctuary.Database.Entities;
 using Sanctuary.Game;
+using Sanctuary.Gateway.Helpers;
 using Sanctuary.Packet;
 using Sanctuary.Packet.Common;
 using Sanctuary.Packet.Common.Attributes;
-using Sanctuary.Packet.Common.Chat;
 
 namespace Sanctuary.Gateway.Handlers;
 
@@ -48,7 +48,7 @@ public static class CommandPacketIgnoreRequestHandler
 
         if (dbCharacterToIgnore is null)
         {
-            SendSystemMessage(connection, "Player not found.");
+            ChatHelper.SendSystemMessage(connection, "Player not found.");
             return true;
         }
 
@@ -58,7 +58,7 @@ public static class CommandPacketIgnoreRequestHandler
 
         if (requesterCharacterId == targetCharacterId)
         {
-            SendSystemMessage(connection, "You cannot ignore yourself.");
+            ChatHelper.SendSystemMessage(connection, "You cannot ignore yourself.");
             return true;
         }
 
@@ -66,7 +66,7 @@ public static class CommandPacketIgnoreRequestHandler
         {
             if (connection.Player.Ignores.Any(x => x.Guid == ignoredCharacterGuid))
             {
-                SendSystemMessage(connection, "That player is already ignored.");
+                ChatHelper.SendSystemMessage(connection, "That player is already ignored.");
                 return true;
             }
 
@@ -76,7 +76,7 @@ public static class CommandPacketIgnoreRequestHandler
 
             if (areFriends)
             {
-                SendSystemMessage(connection, "You cannot ignore a player on your friends list.");
+                ChatHelper.SendSystemMessage(connection, "You cannot ignore a player on your friends list.");
                 return true;
             }
 
@@ -117,7 +117,7 @@ public static class CommandPacketIgnoreRequestHandler
 
             if (dbIgnoreToRemove.ExecuteDelete() <= 0)
             {
-                SendSystemMessage(connection, "That player is not on your ignore list.");
+                ChatHelper.SendSystemMessage(connection, "That player is not on your ignore list.");
                 return true;
             }
 
@@ -134,12 +134,4 @@ public static class CommandPacketIgnoreRequestHandler
         return true;
     }
 
-    private static void SendSystemMessage(GatewayConnection connection, string message)
-    {
-        connection.Player.SendTunneled(new PacketChat
-        {
-            Channel = ChatChannel.System,
-            Message = message
-        });
-    }
 }

--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketIgnoreRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketIgnoreRequestHandler.cs
@@ -12,6 +12,7 @@ using Sanctuary.Game;
 using Sanctuary.Packet;
 using Sanctuary.Packet.Common;
 using Sanctuary.Packet.Common.Attributes;
+using Sanctuary.Packet.Common.Chat;
 
 namespace Sanctuary.Gateway.Handlers;
 
@@ -41,23 +42,45 @@ public static class CommandPacketIgnoreRequestHandler
 
         _logger.LogTrace("Received {name} packet. ( {packet} )", nameof(CommandPacketIgnoreRequest), packet);
 
-
         using var dbContext = _dbContextFactory.CreateDbContext();
 
         var dbCharacterToIgnore = dbContext.Characters.FirstOrDefault(x => x.FullName == packet.Name.FullName);
 
         if (dbCharacterToIgnore is null)
+        {
+            SendSystemMessage(connection, "Player not found.");
             return true;
+        }
 
-        if (!_zoneManager.TryGetPlayer(GuidHelper.GetPlayerGuid(dbCharacterToIgnore.Id), out var playerToIgnore))
+        var ignoredCharacterGuid = GuidHelper.GetPlayerGuid(dbCharacterToIgnore.Id);
+        var requesterCharacterId = GuidHelper.GetPlayerId(connection.Player.Guid);
+        var targetCharacterId = dbCharacterToIgnore.Id;
+
+        if (requesterCharacterId == targetCharacterId)
+        {
+            SendSystemMessage(connection, "You cannot ignore yourself.");
             return true;
+        }
 
         if (packet.Ignore)
         {
-            if (connection.Player.Ignores.Any(x => x.Guid == playerToIgnore.Guid))
+            if (connection.Player.Ignores.Any(x => x.Guid == ignoredCharacterGuid))
+            {
+                SendSystemMessage(connection, "That player is already ignored.");
                 return true;
+            }
 
-            var dbCharacter = dbContext.Characters.FirstOrDefault(x => x.Id == GuidHelper.GetPlayerId(connection.Player.Guid));
+            var areFriends = dbContext.Friends.Any(x =>
+                (x.CharacterId == requesterCharacterId && x.FriendCharacterId == targetCharacterId) ||
+                (x.CharacterId == targetCharacterId && x.FriendCharacterId == requesterCharacterId));
+
+            if (areFriends)
+            {
+                SendSystemMessage(connection, "You cannot ignore a player on your friends list.");
+                return true;
+            }
+
+            var dbCharacter = dbContext.Characters.FirstOrDefault(x => x.Id == requesterCharacterId);
 
             if (dbCharacter is null)
                 return true;
@@ -73,8 +96,8 @@ public static class CommandPacketIgnoreRequestHandler
 
             var ignoreData = new IgnoreData
             {
-                Guid = playerToIgnore.Guid,
-                Name = playerToIgnore.Name.FullName
+                Guid = ignoredCharacterGuid,
+                Name = dbCharacterToIgnore.FullName
             };
 
             connection.Player.Ignores.Add(ignoreData);
@@ -89,25 +112,34 @@ public static class CommandPacketIgnoreRequestHandler
         else
         {
             var dbIgnoreToRemove = dbContext.Ignores.Where(x =>
-                x.CharacterId == GuidHelper.GetPlayerId(connection.Player.Guid) &&
-                x.IgnoreCharacterId == dbCharacterToIgnore.Id);
+                x.CharacterId == requesterCharacterId &&
+                x.IgnoreCharacterId == targetCharacterId);
 
             if (dbIgnoreToRemove.ExecuteDelete() <= 0)
+            {
+                SendSystemMessage(connection, "That player is not on your ignore list.");
                 return true;
+            }
 
-            connection.Player.Ignores.RemoveAll(x => x.Guid == playerToIgnore.Guid);
-
-            if (dbContext.SaveChanges() <= 0)
-                return true;
+            connection.Player.Ignores.RemoveAll(x => x.Guid == ignoredCharacterGuid);
 
             var ignoreRemovePacket = new IgnoreRemovePacket
             {
-                Guid = playerToIgnore.Guid
+                Guid = ignoredCharacterGuid
             };
 
             connection.SendTunneled(ignoreRemovePacket);
         }
 
         return true;
+    }
+
+    private static void SendSystemMessage(GatewayConnection connection, string message)
+    {
+        connection.Player.SendTunneled(new PacketChat
+        {
+            Channel = ChatChannel.System,
+            Message = message
+        });
     }
 }

--- a/src/Sanctuary.Gateway/Handlers/PacketLoginHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketLoginHandler.cs
@@ -103,6 +103,26 @@ public static class PacketLoginHandler
             return true;
         }
 
+        var orphanedIgnores = character.Ignores
+            .Where(x => x.IgnoreCharacter is null)
+            .ToList();
+
+        if (orphanedIgnores.Count > 0)
+        {
+            var orphanedIgnoreIds = orphanedIgnores
+                .Select(x => x.IgnoreCharacterId)
+                .ToList();
+
+            dbContext.Ignores
+                .Where(x => x.CharacterId == character.Id && orphanedIgnoreIds.Contains(x.IgnoreCharacterId))
+                .ExecuteDelete();
+
+            foreach (var orphanedIgnore in orphanedIgnores)
+            {
+                character.Ignores.Remove(orphanedIgnore);
+            }
+        }
+
 #if !DEBUG
         var result = dbContext.Characters
             .Where(x => x.Id == character.Id)

--- a/src/Sanctuary.Gateway/Helpers/ChatHelper.cs
+++ b/src/Sanctuary.Gateway/Helpers/ChatHelper.cs
@@ -1,0 +1,16 @@
+using Sanctuary.Packet;
+using Sanctuary.Packet.Common.Chat;
+
+namespace Sanctuary.Gateway.Helpers;
+
+public static class ChatHelper
+{
+    public static void SendSystemMessage(GatewayConnection connection, string message)
+    {
+        connection.Player.SendTunneled(new PacketChat
+        {
+            Channel = ChatChannel.System,
+            Message = message
+        });
+    }
+}

--- a/src/Sanctuary.Login/Handlers/CharacterDeleteRequestHandler.cs
+++ b/src/Sanctuary.Login/Handlers/CharacterDeleteRequestHandler.cs
@@ -63,8 +63,13 @@ public static class CharacterDeleteRequestHandler
         try
         {
             // Delete references first to avoid foreign key constraint violations.
-            var friends = dbContext.Friends.Where(f => f.FriendCharacterId == character.Id);
-            var ignores = dbContext.Ignores.Where(i => i.IgnoreCharacterId == character.Id);
+            var characterId = character.Id;
+
+            var friends = dbContext.Friends.Where(f =>
+                f.CharacterId == characterId || f.FriendCharacterId == characterId);
+
+            var ignores = dbContext.Ignores.Where(i =>
+                i.CharacterId == characterId || i.IgnoreCharacterId == characterId);
 
             dbContext.Friends.RemoveRange(friends);
             dbContext.Ignores.RemoveRange(ignores);


### PR DESCRIPTION
ignore fixes on top of current main. ignore and unignore now work against saved character records instead of only online players, meaning players can manage ignores even when another character is offline. system feedback for failed ignore action is clearer now as well. 

additionally ignoring yourself or someone already present on your friends list is blocked. ignore records are removed when a character is deleted and old orphaned ignore records are cleaned up so that stale database rows do not crash players while loading.