### PR TITLE
Send visible NPC notifications

### DIFF
--- a/src/Sanctuary.Game/Entities/Npc.cs
+++ b/src/Sanctuary.Game/Entities/Npc.cs
@@ -61,7 +61,7 @@ public class Npc : IEntity
 
     public byte CursorId { get; set; }
 
-    // public NotificationInfo? Notification { get; set; }
+    public NotificationInfo? Notification { get; set; }
 
     public List<CharacterAttachmentData> Attachments { get; set; } = [];
 

--- a/src/Sanctuary.Game/Entities/Player.cs
+++ b/src/Sanctuary.Game/Entities/Player.cs
@@ -270,7 +270,7 @@ public sealed class Player : ClientPcData, IEntity
             SendTunneled(playerUpdatePacketAddNpc);
         }
 
-        /* var playerUpdatePacketNpcRelevance = new PlayerUpdatePacketNpcRelevance();
+        var playerUpdatePacketNpcRelevance = new PlayerUpdatePacketNpcRelevance();
 
         foreach (var npc in npcs)
         {
@@ -281,8 +281,7 @@ public sealed class Player : ClientPcData, IEntity
             {
                 Guid = npc.Guid,
                 HasCursor = true,
-                CursorId = npc.CursorId,
-                Unknown2 = false
+                CursorId = npc.CursorId
             });
         }
 
@@ -297,12 +296,13 @@ public sealed class Player : ClientPcData, IEntity
                 continue;
 
             playerUpdatePacketAddNotifications.Notifications.Add(npc.Notification);
-
-            SendTunneled(playerUpdatePacketAddNotifications);
         }
 
+        if (playerUpdatePacketAddNotifications.Notifications.Count > 0)
+            SendTunneled(playerUpdatePacketAddNotifications);
+
         foreach (var npc in npcs)
-            VisibleNpcs.TryAdd(npc.Guid, npc); */
+            VisibleNpcs.TryAdd(npc.Guid, npc);
     }
 
     public void OnAddVisiblePlayers(params IEnumerable<Player> players)

--- a/src/Sanctuary.Packet.Common/NotificationInfo.cs
+++ b/src/Sanctuary.Packet.Common/NotificationInfo.cs
@@ -1,0 +1,48 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet.Common;
+
+public class NotificationInfo : ISerializableType
+{
+    public ulong Guid { get; set; }
+
+    /// <summary>
+    /// Observed in packet logs. When true, the client expects the compact payload.
+    /// </summary>
+    public bool IsCompact { get; set; }
+
+    public int NotificationType { get; set; }
+
+    public int IconId { get; set; }
+    public int IconState { get; set; }
+    public int Unknown { get; set; }
+    public int NameId { get; set; }
+    public int ReferenceId { get; set; }
+    public int Unknown2 { get; set; }
+
+    public bool Unknown3 { get; set; }
+    public bool Enabled { get; set; } = true;
+
+    public void Serialize(PacketWriter writer)
+    {
+        writer.Write(Guid);
+        writer.Write(IsCompact);
+
+        if (IsCompact)
+        {
+            writer.Write(NotificationType);
+            writer.Write(Enabled);
+            return;
+        }
+
+        writer.Write(NotificationType);
+        writer.Write(IconId);
+        writer.Write(IconState);
+        writer.Write(Unknown);
+        writer.Write(NameId);
+        writer.Write(ReferenceId);
+        writer.Write(Unknown2);
+        writer.Write(Unknown3);
+        writer.Write(Enabled);
+    }
+}

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketAddNotifications.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketAddNotifications.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+using Sanctuary.Core.IO;
+using Sanctuary.Packet.Common;
+
+namespace Sanctuary.Packet;
+
+public class PlayerUpdatePacketAddNotifications : BasePlayerUpdatePacket, ISerializablePacket
+{
+    public new const short OpCode = 10;
+
+    public List<NotificationInfo> Notifications { get; set; } = [];
+
+    public PlayerUpdatePacketAddNotifications() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(Notifications);
+
+        return writer.Buffer;
+    }
+}


### PR DESCRIPTION
## Summary
- add typed `PlayerUpdatePacketAddNotifications` and `NotificationInfo` serialization
- expose optional `Npc.Notification` metadata
- send NPC cursor relevance and batched notifications when NPCs become visible

## Why
`PlayerUpdatePacketAddNotifications` is already listed in the packet reader map, and `Player.OnAddVisibleNpcs` had dormant handling for NPC relevance/notifications. This wires that intended path so NPC-backed interactables can provide notification metadata to the client.

## Testing
- `dotnet build .\src\Sanctuary.sln --no-incremental -p:BaseOutputPath=.buildcheck\`