### PR TITLE
No-op on friend req accept if already friends (fixes #49)

### DIFF
--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketConfirmFriendResponseHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketConfirmFriendResponseHandler.cs
@@ -53,6 +53,9 @@ public static class CommandPacketConfirmFriendResponseHandler
         switch (packet.Status)
         {
             case 0:
+                if (connection.Player.Friends.Any(x => x.Guid == player.Guid))
+                    return true;
+
                 OnAccept(player, connection.Player);
 
                 friendMessagePacket.Type = FriendMessageType.FriendAddRequestAccepted;


### PR DESCRIPTION
We currently only have checks for already-friends at request time, but not accept time.