### PR TITLE
Fix show mounted players to other clients and some cleanup

### DIFF
--- a/src/Sanctuary.Game/Entities/Mount.cs
+++ b/src/Sanctuary.Game/Entities/Mount.cs
@@ -52,13 +52,8 @@ public class Mount : Npc
     {
         var packet = base.GetAddNpcPacket();
 
-        packet.RiderGuid = Rider.Guid;
+        packet.RiderGuid = 0;
 
         return packet;
-    }
-
-    public override void Dispose()
-    {
-        base.Dispose();
     }
 }

--- a/src/Sanctuary.Game/Entities/Mount.cs
+++ b/src/Sanctuary.Game/Entities/Mount.cs
@@ -56,4 +56,18 @@ public class Mount : Npc
 
         return packet;
     }
+
+    public PacketMountResponse GetMountResponsePacket()
+    {
+        return new PacketMountResponse
+        {
+            RiderGuid = Rider.Guid,
+            MountGuid = Guid,
+            Seat = Seat,
+            QueuePosition = QueuePosition,
+            Unknown = 1,
+            CompositeEffectId = 46, // PFX_Teleport_Flash
+            NameVerticalOffset = Definition.NameVerticalOffset
+        };
+    }
 }

--- a/src/Sanctuary.Game/Entities/Player.cs
+++ b/src/Sanctuary.Game/Entities/Player.cs
@@ -263,12 +263,10 @@ public sealed class Player : ClientPcData, IEntity
     {
         foreach (var npc in npcs)
         {
-            var playerUpdatePacketAddNpc = npc.GetAddNpcPacket();
+            if (npc is Mount)
+                continue;
 
-            if (npc is Mount mount && mount.Rider.Guid == Guid)
-                playerUpdatePacketAddNpc.RiderGuid = 0;
-
-            SendTunneled(playerUpdatePacketAddNpc);
+            SendTunneled(npc.GetAddNpcPacket());
         }
 
         var playerUpdatePacketNpcRelevance = new PlayerUpdatePacketNpcRelevance();
@@ -310,9 +308,29 @@ public sealed class Player : ClientPcData, IEntity
     {
         foreach (var player in players)
         {
-            var playerUpdatePacketAddPc = player.GetAddPcPacket();
+            if (player.Mount is not null)
+            {
+                var addPc = player.GetAddPcPacket();
+                addPc.MountGuid = 0;
+                addPc.MountSeat = -1;
+                addPc.MountQueuePosition = -1;
+                addPc.NameVerticalOffset = 0;
 
-            SendTunneled(playerUpdatePacketAddPc);
+                SendTunneled(addPc);
+                SendTunneled(player.Mount.GetAddNpcPacket());
+                SendTunneled(new PacketMountResponse
+                {
+                    RiderGuid = player.Guid,
+                    MountGuid = player.Mount.Guid,
+                    Seat = player.Mount.Seat,
+                    QueuePosition = player.Mount.QueuePosition,
+                    Unknown = 1,
+                    CompositeEffectId = 46,
+                    NameVerticalOffset = player.Mount.Definition.NameVerticalOffset
+                });
+            }
+            else
+                SendTunneled(player.GetAddPcPacket());
         }
 
         foreach (var player in players)
@@ -323,28 +341,10 @@ public sealed class Player : ClientPcData, IEntity
     {
         foreach (var npc in npcs)
         {
-            if (npc is Mount mount)
-            {
-                var playerUpdatePacketRemovePlayerGracefully = new PlayerUpdatePacketRemovePlayerGracefully();
+            if (npc is Mount)
+                continue;
 
-                playerUpdatePacketRemovePlayerGracefully.Guid = npc.Guid;
-
-                playerUpdatePacketRemovePlayerGracefully.Animate = false;
-                playerUpdatePacketRemovePlayerGracefully.Delay = 0;
-                playerUpdatePacketRemovePlayerGracefully.EffectDelay = 0;
-                playerUpdatePacketRemovePlayerGracefully.CompositeEffectId = 46;
-                playerUpdatePacketRemovePlayerGracefully.Duration = 1000;
-
-                SendTunneled(playerUpdatePacketRemovePlayerGracefully);
-            }
-            else
-            {
-                var playerUpdatePacketRemovePlayer = new PlayerUpdatePacketRemovePlayer();
-
-                playerUpdatePacketRemovePlayer.Guid = npc.Guid;
-
-                SendTunneled(playerUpdatePacketRemovePlayer);
-            }
+            SendTunneled(new PlayerUpdatePacketRemovePlayer { Guid = npc.Guid });
         }
 
         foreach (var npc in npcs)
@@ -355,11 +355,10 @@ public sealed class Player : ClientPcData, IEntity
     {
         foreach (var player in players)
         {
-            var playerUpdatePacketRemovePlayer = new PlayerUpdatePacketRemovePlayer();
+            SendTunneled(new PlayerUpdatePacketRemovePlayer { Guid = player.Guid });
 
-            playerUpdatePacketRemovePlayer.Guid = player.Guid;
-
-            SendTunneled(playerUpdatePacketRemovePlayer);
+            if (player.Mount is not null)
+                SendTunneled(new PlayerUpdatePacketRemovePlayer { Guid = player.Mount.Guid });
         }
 
         foreach (var player in players)
@@ -561,14 +560,13 @@ public sealed class Player : ClientPcData, IEntity
 
     public void Dispose()
     {
-        Mount?.Dispose();
-        Mount = null;
-
         foreach (var visiblePlayer in VisiblePlayers)
             visiblePlayer.Value.OnRemoveVisiblePlayers([this]);
 
-        ZoneTile.Entities.Remove(Guid, out _);
+        Mount?.Dispose();
+        Mount = null;
 
+        ZoneTile.Entities.Remove(Guid, out _);
         Zone.TryRemovePlayer(Guid);
     }
 }

--- a/src/Sanctuary.Game/Entities/Player.cs
+++ b/src/Sanctuary.Game/Entities/Player.cs
@@ -133,6 +133,8 @@ public sealed class Player : ClientPcData, IEntity
         Position = position;
         Rotation = rotation;
 
+        Mount?.UpdatePosition(position, rotation, updateZoneArea);
+
         if (Visible)
         {
             UpdateZoneTile();
@@ -318,16 +320,7 @@ public sealed class Player : ClientPcData, IEntity
 
                 SendTunneled(addPc);
                 SendTunneled(player.Mount.GetAddNpcPacket());
-                SendTunneled(new PacketMountResponse
-                {
-                    RiderGuid = player.Guid,
-                    MountGuid = player.Mount.Guid,
-                    Seat = player.Mount.Seat,
-                    QueuePosition = player.Mount.QueuePosition,
-                    Unknown = 1,
-                    CompositeEffectId = 46,
-                    NameVerticalOffset = player.Mount.Definition.NameVerticalOffset
-                });
+                SendTunneled(player.Mount.GetMountResponsePacket());
             }
             else
                 SendTunneled(player.GetAddPcPacket());

--- a/src/Sanctuary.Gateway/Handlers/MountBasePacket/PacketDismountRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/MountBasePacket/PacketDismountRequestHandler.cs
@@ -27,20 +27,30 @@ public static class PacketDismountRequestHandler
         if (connection.Player.Mount is null)
             return true;
 
-        var packetDismountResponse = new PacketDismountResponse();
-
-        packetDismountResponse.RiderGuid = connection.Player.Guid;
-        packetDismountResponse.CompositeEffectId = 0; // PFX_Teleport_Flash
+        var packetDismountResponse = new PacketDismountResponse
+        {
+            RiderGuid = connection.Player.Guid,
+            CompositeEffectId = 0,
+        };
 
         connection.Player.SendTunneledToVisible(packetDismountResponse, true);
-
-        connection.Player.Mount.Dispose();
-        connection.Player.Mount = null;
 
         connection.Player.UpdateCharacterStats(
             CharacterStats.MaxMovementSpeed.Set(8f),
             CharacterStats.GlideEnabled.Set(0),
             CharacterStats.JumpHeight.Set(0f));
+
+        connection.Player.SendTunneledToVisible(new PlayerUpdatePacketRemovePlayerGracefully
+        {
+            Guid = connection.Player.Mount.Guid,
+            Animate = false,
+            Delay = 0,
+            EffectDelay = 0,
+            CompositeEffectId = 0,
+        }, true);
+
+        connection.Player.Mount.Dispose();
+        connection.Player.Mount = null;
 
         return true;
     }

--- a/src/Sanctuary.Gateway/Handlers/MountBasePacket/PacketMountSpawnHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/MountBasePacket/PacketMountSpawnHandler.cs
@@ -76,22 +76,20 @@ public static class PacketMountSpawnHandler
 
         mount.UpdatePosition(connection.Player.Position, connection.Player.Rotation);
 
-        var packetMountResponse = new PacketMountResponse();
+        foreach (var visiblePlayer in connection.Player.VisiblePlayers)
+            visiblePlayer.Value.OnAddVisiblePlayers([connection.Player]);
 
-        packetMountResponse.RiderGuid = mount.Rider.Guid;
-        packetMountResponse.MountGuid = mount.Guid;
-
-        packetMountResponse.Seat = mount.Seat;
-
-        packetMountResponse.QueuePosition = mount.QueuePosition;
-
-        packetMountResponse.Unknown = 1;
-
-        packetMountResponse.CompositeEffectId = 46; // PFX_Teleport_Flash
-
-        packetMountResponse.NameVerticalOffset = mountDefinition.NameVerticalOffset;
-
-        connection.Player.SendTunneledToVisible(packetMountResponse, true);
+        connection.Player.SendTunneled(mount.GetAddNpcPacket());
+        connection.Player.SendTunneled(new PacketMountResponse
+        {
+            RiderGuid = connection.Player.Guid,
+            MountGuid = mount.Guid,
+            Seat = mount.Seat,
+            QueuePosition = mount.QueuePosition,
+            Unknown = 1,
+            CompositeEffectId = 46,
+            NameVerticalOffset = mountDefinition.NameVerticalOffset
+        });
 
         var mountStats = mountDefinition.Stats;
 

--- a/src/Sanctuary.Gateway/Handlers/MountBasePacket/PacketMountSpawnHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/MountBasePacket/PacketMountSpawnHandler.cs
@@ -74,22 +74,13 @@ public static class PacketMountSpawnHandler
 
         connection.Player.Mount = mount;
 
-        mount.UpdatePosition(connection.Player.Position, connection.Player.Rotation);
+        connection.Player.UpdatePosition(connection.Player.Position, connection.Player.Rotation);
 
         foreach (var visiblePlayer in connection.Player.VisiblePlayers)
             visiblePlayer.Value.OnAddVisiblePlayers([connection.Player]);
 
         connection.Player.SendTunneled(mount.GetAddNpcPacket());
-        connection.Player.SendTunneled(new PacketMountResponse
-        {
-            RiderGuid = connection.Player.Guid,
-            MountGuid = mount.Guid,
-            Seat = mount.Seat,
-            QueuePosition = mount.QueuePosition,
-            Unknown = 1,
-            CompositeEffectId = 46,
-            NameVerticalOffset = mountDefinition.NameVerticalOffset
-        });
+        connection.Player.SendTunneled(mount.GetMountResponsePacket());
 
         var mountStats = mountDefinition.Stats;
 

--- a/src/Sanctuary.Gateway/Handlers/PacketClientFinishedLoadingHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketClientFinishedLoadingHandler.cs
@@ -24,33 +24,25 @@ public static class PacketClientFinishedLoadingHandler
         _logger.LogTrace("Received {name} packet.", nameof(PacketClientFinishedLoading));
 
         connection.Player.Visible = true;
-
         connection.Player.UpdatePosition(connection.Player.Position, connection.Player.Rotation);
 
-        var mount = connection.Player.Mount;
-
-        if (mount is not null)
+        if (connection.Player.Mount is not null)
         {
-            mount.Visible = true;
+            var mount = connection.Player.Mount;
 
+            mount.Visible = true;
             mount.UpdatePosition(connection.Player.Position, connection.Player.Rotation);
 
-            var packetMountResponse = new PacketMountResponse();
-
-            packetMountResponse.RiderGuid = mount.Rider.Guid;
-            packetMountResponse.MountGuid = mount.Guid;
-
-            packetMountResponse.Seat = mount.Seat;
-
-            packetMountResponse.QueuePosition = mount.QueuePosition;
-
-            packetMountResponse.Unknown = 1;
-
-            packetMountResponse.CompositeEffectId = 46; // PFX_Teleport_Flash
-
-            // packetMountResponse.NameVerticalOffset = mountDefinition.NameVerticalOffset;
-
-            connection.Player.SendTunneled(packetMountResponse);
+            connection.Player.SendTunneled(new PacketMountResponse
+            {
+                RiderGuid = connection.Player.Guid,
+                MountGuid = mount.Guid,
+                Seat = mount.Seat,
+                QueuePosition = mount.QueuePosition,
+                Unknown = 1,
+                CompositeEffectId = 46,
+                NameVerticalOffset = mount.Definition.NameVerticalOffset
+            });
         }
 
         connection.Player.Zone.OnClientFinishedLoading(connection.Player);

--- a/src/Sanctuary.Gateway/Handlers/PacketClientFinishedLoadingHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketClientFinishedLoadingHandler.cs
@@ -28,21 +28,9 @@ public static class PacketClientFinishedLoadingHandler
 
         if (connection.Player.Mount is not null)
         {
-            var mount = connection.Player.Mount;
+            connection.Player.Mount.Visible = true;
 
-            mount.Visible = true;
-            mount.UpdatePosition(connection.Player.Position, connection.Player.Rotation);
-
-            connection.Player.SendTunneled(new PacketMountResponse
-            {
-                RiderGuid = connection.Player.Guid,
-                MountGuid = mount.Guid,
-                Seat = mount.Seat,
-                QueuePosition = mount.QueuePosition,
-                Unknown = 1,
-                CompositeEffectId = 46,
-                NameVerticalOffset = mount.Definition.NameVerticalOffset
-            });
+            connection.Player.SendTunneled(connection.Player.Mount.GetMountResponsePacket());
         }
 
         connection.Player.Zone.OnClientFinishedLoading(connection.Player);

--- a/src/Sanctuary.Gateway/Handlers/PacketWorldTeleportRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketWorldTeleportRequestHandler.cs
@@ -40,7 +40,6 @@ public static class PacketWorldTeleportRequestHandler
         var rotation = player.Rotation;
 
         connection.Player.UpdatePosition(position, rotation, updateZoneArea: false);
-        connection.Player.Mount?.UpdatePosition(position, rotation);
 
         var clientUpdatePacketUpdateLocation = new ClientUpdatePacketUpdateLocation
         {

--- a/src/Sanctuary.Gateway/Handlers/PacketWorldTeleportRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketWorldTeleportRequestHandler.cs
@@ -39,8 +39,8 @@ public static class PacketWorldTeleportRequestHandler
         var position = player.Position;
         var rotation = player.Rotation;
 
-        connection.Player.Mount?.UpdatePosition(position, rotation);
         connection.Player.UpdatePosition(position, rotation, updateZoneArea: false);
+        connection.Player.Mount?.UpdatePosition(position, rotation);
 
         var clientUpdatePacketUpdateLocation = new ClientUpdatePacketUpdateLocation
         {

--- a/src/Sanctuary.Gateway/Handlers/PacketZoneSafeTeleportRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketZoneSafeTeleportRequestHandler.cs
@@ -50,8 +50,8 @@ public static class PacketZoneSafeTeleportRequestHandler
         var position = pointOfInterest.SpawnPosition;
         var rotation = new Quaternion(rotationZ, 0f, rotationX, 0f);
 
-        connection.Player.Mount?.UpdatePosition(position, rotation);
         connection.Player.UpdatePosition(position, rotation, updateZoneArea: false);
+        connection.Player.Mount?.UpdatePosition(position, rotation);
 
         var clientUpdatePacketUpdateLocation = new ClientUpdatePacketUpdateLocation
         {

--- a/src/Sanctuary.Gateway/Handlers/PacketZoneSafeTeleportRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketZoneSafeTeleportRequestHandler.cs
@@ -51,7 +51,6 @@ public static class PacketZoneSafeTeleportRequestHandler
         var rotation = new Quaternion(rotationZ, 0f, rotationX, 0f);
 
         connection.Player.UpdatePosition(position, rotation, updateZoneArea: false);
-        connection.Player.Mount?.UpdatePosition(position, rotation);
 
         var clientUpdatePacketUpdateLocation = new ClientUpdatePacketUpdateLocation
         {

--- a/src/Sanctuary.Gateway/Handlers/PacketZoneTeleportRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketZoneTeleportRequestHandler.cs
@@ -46,8 +46,8 @@ public static class PacketZoneTeleportRequestHandler
         var position = pointOfInterest.SpawnPosition;
         var rotation = new Quaternion(rotationZ, 0f, rotationX, 0f);
 
-        connection.Player.Mount?.UpdatePosition(position, rotation);
         connection.Player.UpdatePosition(position, rotation, updateZoneArea: false);
+        connection.Player.Mount?.UpdatePosition(position, rotation);
 
         var clientUpdatePacketUpdateLocation = new ClientUpdatePacketUpdateLocation
         {

--- a/src/Sanctuary.Gateway/Handlers/PacketZoneTeleportRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketZoneTeleportRequestHandler.cs
@@ -47,7 +47,6 @@ public static class PacketZoneTeleportRequestHandler
         var rotation = new Quaternion(rotationZ, 0f, rotationX, 0f);
 
         connection.Player.UpdatePosition(position, rotation, updateZoneArea: false);
-        connection.Player.Mount?.UpdatePosition(position, rotation);
 
         var clientUpdatePacketUpdateLocation = new ClientUpdatePacketUpdateLocation
         {

--- a/src/Sanctuary.Gateway/Handlers/PlayerUpdatePacketJumpHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PlayerUpdatePacketJumpHandler.cs
@@ -29,7 +29,6 @@ public static class PlayerUpdatePacketJumpHandler
 
         // _logger.LogTrace("Received {name} packet. ( {packet} )", nameof(PlayerUpdatePacketJump), packet);
 
-        connection.Player.Mount?.UpdatePosition(packet.Position, packet.Rotation);
         connection.Player.UpdatePosition(packet.Position, packet.Rotation);
 
         connection.Player.SendTunneledToVisible(packet);

--- a/src/Sanctuary.Gateway/Handlers/PlayerUpdatePacketUpdatePositionHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PlayerUpdatePacketUpdatePositionHandler.cs
@@ -29,7 +29,6 @@ public static class PlayerUpdatePacketUpdatePositionHandler
 
         // _logger.LogTrace("Received {name} packet. ( {packet} )", nameof(PlayerUpdatePacketUpdatePosition), packet);
 
-        connection.Player.Mount?.UpdatePosition(packet.Position, packet.Rotation);
         connection.Player.UpdatePosition(packet.Position, packet.Rotation);
 
         connection.Player.SendTunneledToVisible(packet);


### PR DESCRIPTION
Fixes mounted players not appearing correctly to other clients. Mount visibility now uses the same packet flow the client expects, and dismount/teleport/disconnect edge cases are handled more reliably.