### PR TITLE
Stop assigning default title on character create

### DIFF
--- a/src/Sanctuary.Login/login.json
+++ b/src/Sanctuary.Login/login.json
@@ -7,7 +7,7 @@
 
     "IsLocked": false,
 
-    "DefaultTitleId": 2,
+    "DefaultTitleId": 0,
     "DefaultProfileId": 1,
 
     "StartingCoins": 999999999,


### PR DESCRIPTION
This removes the sniper title when joining for the first time