### PR TITLE
Fix mount sync after teleport and spawn-only composite effect

### DIFF
--- a/src/Sanctuary.Game/Entities/Mount.cs
+++ b/src/Sanctuary.Game/Entities/Mount.cs
@@ -66,7 +66,7 @@ public class Mount : Npc
             Seat = Seat,
             QueuePosition = QueuePosition,
             Unknown = 1,
-            CompositeEffectId = 46, // PFX_Teleport_Flash
+            CompositeEffectId = 0, // PFX_Teleport_Flash
             NameVerticalOffset = Definition.NameVerticalOffset
         };
     }

--- a/src/Sanctuary.Gateway/Handlers/MountBasePacket/PacketMountSpawnHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/MountBasePacket/PacketMountSpawnHandler.cs
@@ -80,7 +80,11 @@ public static class PacketMountSpawnHandler
             visiblePlayer.Value.OnAddVisiblePlayers([connection.Player]);
 
         connection.Player.SendTunneled(mount.GetAddNpcPacket());
-        connection.Player.SendTunneled(mount.GetMountResponsePacket());
+
+        var mountResponse = mount.GetMountResponsePacket();
+        mountResponse.CompositeEffectId = 46; // PFX_Teleport_Flash
+
+        connection.Player.SendTunneledToVisible(mountResponse, sendToSelf: true);
 
         var mountStats = mountDefinition.Stats;
 

--- a/src/Sanctuary.Gateway/Handlers/PacketClientFinishedLoadingHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketClientFinishedLoadingHandler.cs
@@ -24,12 +24,15 @@ public static class PacketClientFinishedLoadingHandler
         _logger.LogTrace("Received {name} packet.", nameof(PacketClientFinishedLoading));
 
         connection.Player.Visible = true;
+
+        if (connection.Player.Mount is not null)
+            connection.Player.Mount.Visible = true;
+
         connection.Player.UpdatePosition(connection.Player.Position, connection.Player.Rotation);
 
         if (connection.Player.Mount is not null)
         {
-            connection.Player.Mount.Visible = true;
-
+            connection.Player.SendTunneled(connection.Player.Mount.GetAddNpcPacket());
             connection.Player.SendTunneled(connection.Player.Mount.GetMountResponsePacket());
         }
 


### PR DESCRIPTION
Fixes mount client desync after atlas/safe teleport and stops the teleport flash `CompositeEffectId`  from playing when players become visible again. This should fix the effect being spammed if alot of players are in a zone, on a mount.