### PR TITLE
Assign membership by default, make configurable on API server

### DIFF
--- a/src/Sanctuary.WebAPI/Endpoints/AuthEndpoints.cs
+++ b/src/Sanctuary.WebAPI/Endpoints/AuthEndpoints.cs
@@ -81,6 +81,7 @@ public static class AuthEndpoints
     private static async Task<IResult> RegisterHandlerAsync(
         RegisterRequestModel request,
         CancellationToken cancellationToken,
+        IOptions<WebAPIOptions> webAPIOptions,
         IDbContextFactory<DatabaseContext> dbContextFactory)
     {
         if (!MiniValidator.TryValidate(request, out var errors))
@@ -103,7 +104,8 @@ public static class AuthEndpoints
         var dbUser = new DbUser
         {
             Username = request.Username,
-            Password = hashedPassword
+            Password = hashedPassword,
+            IsMember = webAPIOptions.Value.MemberByDefault ?? true,
         };
 
         await dbContext.Users.AddAsync(dbUser, cancellationToken);

--- a/src/Sanctuary.WebAPI/Options/WebAPIOptions.cs
+++ b/src/Sanctuary.WebAPI/Options/WebAPIOptions.cs
@@ -5,4 +5,6 @@ public class WebAPIOptions
     public const string Section = "WebAPI";
 
     public string? LaunchArguments { get; set; }
+
+    public bool? MemberByDefault { get; set; }
 }

--- a/src/Sanctuary.WebAPI/appsettings.Development.json
+++ b/src/Sanctuary.WebAPI/appsettings.Development.json
@@ -7,6 +7,7 @@
     }
   },
   "WebAPI": {
-    "LaunchArguments": "AssetDelivery:IndirectServerAddress=http://osfr.editz.dev/assets Portrait:UploadUrl=http://127.0.0.1:20040/image Logging:Level=6"
+    "LaunchArguments": "AssetDelivery:IndirectServerAddress=http://osfr.editz.dev/assets Portrait:UploadUrl=http://127.0.0.1:20040/image Logging:Level=6",
+    "MemberByDefault": true
   }
 }

--- a/src/Sanctuary.WebAPI/appsettings.json
+++ b/src/Sanctuary.WebAPI/appsettings.json
@@ -6,7 +6,8 @@
     }
   },
   "WebAPI": {
-    "LaunchArguments": "AssetDelivery:IndirectServerAddress=http://osfr.editz.dev/assets Portrait:UploadUrl=http://127.0.0.1:20040/image"
+    "LaunchArguments": "AssetDelivery:IndirectServerAddress=http://osfr.editz.dev/assets Portrait:UploadUrl=http://127.0.0.1:20040/image",
+    "MemberByDefault": true
   },
   "AllowedHosts": "*",
   "Urls": "http://127.0.0.1:20040"


### PR DESCRIPTION
Currently all user accounts are created without memberships, but there's no reason to limit players arbitrarily, especially on their own self-hosted servers. Accounts should have memberships by default.

If, for whatever reason, server owners want to disable memberships, I made it configurable in the WebAPI options.