### PR TITLE
Add PlayerUpdate packet serializers for combat and encounters

### DIFF
--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketAddEffectTagCompositeEffect.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketAddEffectTagCompositeEffect.cs
@@ -2,8 +2,7 @@ using Sanctuary.Core.IO;
 
 namespace Sanctuary.Packet;
 
-// op35 sub41 — attach a LOOPING composite effect to a character as part of a status-effect tag (the
-// visible half of a buff/debuff). Pair with sub42 to stop the loop.
+
 public class PlayerUpdatePacketAddEffectTagCompositeEffect : BasePlayerUpdatePacket, ISerializablePacket
 {
     public new const short OpCode = 41;

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketAddEffectTagCompositeEffect.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketAddEffectTagCompositeEffect.cs
@@ -27,8 +27,7 @@ public class PlayerUpdatePacketAddEffectTagCompositeEffect : BasePlayerUpdatePac
         writer.Write(TagId);
         writer.Write(CompositeEffectId);
         writer.Write(SourceGuid);
-        writer.Write(Unknown);
-        writer.Write(Unknown2);
+        writer.Write(Unused);
 
         return writer.Buffer;
     }

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketAddEffectTagCompositeEffect.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketAddEffectTagCompositeEffect.cs
@@ -11,8 +11,7 @@ public class PlayerUpdatePacketAddEffectTagCompositeEffect : BasePlayerUpdatePac
     public int TagId;
     public int CompositeEffectId;
     public ulong SourceGuid;
-    public int Unknown;
-    public int Unknown2;
+    private long Unused = default;
 
     public PlayerUpdatePacketAddEffectTagCompositeEffect() : base(OpCode)
     {

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketAddEffectTagCompositeEffect.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketAddEffectTagCompositeEffect.cs
@@ -1,0 +1,37 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op35 sub41 — attach a LOOPING composite effect to a character as part of a status-effect tag (the
+// visible half of a buff/debuff). Pair with sub42 to stop the loop.
+public class PlayerUpdatePacketAddEffectTagCompositeEffect : BasePlayerUpdatePacket, ISerializablePacket
+{
+    public new const short OpCode = 41;
+
+    public ulong Guid;
+    public int TagId;
+    public int CompositeEffectId;
+    public ulong SourceGuid;
+    public int Unknown;
+    public int Unknown2;
+
+    public PlayerUpdatePacketAddEffectTagCompositeEffect() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(Guid);
+        writer.Write(TagId);
+        writer.Write(CompositeEffectId);
+        writer.Write(SourceGuid);
+        writer.Write(Unknown);
+        writer.Write(Unknown2);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketHitPointModification.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketHitPointModification.cs
@@ -3,8 +3,6 @@ using Sanctuary.Core.IO;
 namespace Sanctuary.Packet;
 
 
-// Guid = attacker, Guid2 = victim, Unknown2 = max HP, Unknown3 = current HP after the hit,
-// Unknown4 = the delta (-damage — the floating number).
 
 public class PlayerUpdatePacketHitPointModification : BasePlayerUpdatePacket, ISerializablePacket
 {

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketHitPointModification.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketHitPointModification.cs
@@ -1,0 +1,48 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op35 sub35 — the floating combat damage/heal number over an entity, plus its health-bar update.
+// Guid = attacker, Guid2 = victim, Unknown2 = max HP, Unknown3 = current HP after the hit,
+// Unknown4 = the delta (-damage — the floating number).
+// Unlike CombatPacketAttackProcessed with attacker == local player, this does NOT reset the client's
+// action-bar melee timer, so it's the correct vehicle for the player's own hits.
+public class PlayerUpdatePacketHitPointModification : BasePlayerUpdatePacket, ISerializablePacket
+{
+    public new const short OpCode = 35;
+
+    public ulong Guid;
+    public ulong Guid2;
+
+    public bool Unknown;
+
+    public int Unknown2;
+    public int Unknown3;
+    public int Unknown4;
+
+    public bool Unknown5;
+
+    public PlayerUpdatePacketHitPointModification() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(Guid);
+        writer.Write(Guid2);
+
+        writer.Write(Unknown);
+
+        writer.Write(Unknown2);
+        writer.Write(Unknown3);
+        writer.Write(Unknown4);
+
+        writer.Write(Unknown5);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketHitPointModification.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketHitPointModification.cs
@@ -2,11 +2,10 @@ using Sanctuary.Core.IO;
 
 namespace Sanctuary.Packet;
 
-// op35 sub35 — the floating combat damage/heal number over an entity, plus its health-bar update.
+
 // Guid = attacker, Guid2 = victim, Unknown2 = max HP, Unknown3 = current HP after the hit,
 // Unknown4 = the delta (-damage — the floating number).
-// Unlike CombatPacketAttackProcessed with attacker == local player, this does NOT reset the client's
-// action-bar melee timer, so it's the correct vehicle for the player's own hits.
+
 public class PlayerUpdatePacketHitPointModification : BasePlayerUpdatePacket, ISerializablePacket
 {
     public new const short OpCode = 35;

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketKnockback.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketKnockback.cs
@@ -1,0 +1,41 @@
+using System.Numerics;
+
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op35 sub4 — hurl an actor along a direction (the arc plays client-side).
+public class PlayerUpdatePacketKnockback : BasePlayerUpdatePacket, ISerializablePacket
+{
+    public new const short OpCode = 4;
+
+    public ulong Guid;
+
+    public int Unknown;
+
+    public Vector4 Position;
+
+    /// <summary>Unit XZ direction vector.</summary>
+    public Vector4 Direction;
+
+    public float Magnitude;
+
+    public PlayerUpdatePacketKnockback() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(Guid);
+        writer.Write(Unknown);
+        writer.Write(Position);
+        writer.Write(Direction);
+        writer.Write(Magnitude);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketKnockback.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketKnockback.cs
@@ -15,7 +15,7 @@ public class PlayerUpdatePacketKnockback : BasePlayerUpdatePacket, ISerializable
 
     public Vector4 Position;
 
-    /// <summary>Unit XZ direction vector.</summary>
+    
     public Vector4 Direction;
 
     public float Magnitude;

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketKnockback.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketKnockback.cs
@@ -11,7 +11,7 @@ public class PlayerUpdatePacketKnockback : BasePlayerUpdatePacket, ISerializable
 
     public ulong Guid;
 
-    public int Unknown;
+    public int Animation;
 
     public Vector4 Position;
 

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketKnockback.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketKnockback.cs
@@ -4,7 +4,7 @@ using Sanctuary.Core.IO;
 
 namespace Sanctuary.Packet;
 
-// op35 sub4 — hurl an actor along a direction (the arc plays client-side).
+
 public class PlayerUpdatePacketKnockback : BasePlayerUpdatePacket, ISerializablePacket
 {
     public new const short OpCode = 4;

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketKnockback.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketKnockback.cs
@@ -31,7 +31,7 @@ public class PlayerUpdatePacketKnockback : BasePlayerUpdatePacket, ISerializable
         Write(writer);
 
         writer.Write(Guid);
-        writer.Write(Unknown);
+        writer.Write(Animation);
         writer.Write(Position);
         writer.Write(Direction);
         writer.Write(Magnitude);

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketRemoveEffectTagCompositeEffect.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketRemoveEffectTagCompositeEffect.cs
@@ -1,0 +1,28 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op35 sub42 — stop a looping composite effect attached via sub41 (TagId must match).
+public class PlayerUpdatePacketRemoveEffectTagCompositeEffect : BasePlayerUpdatePacket, ISerializablePacket
+{
+    public new const short OpCode = 42;
+
+    public ulong Guid;
+    public int TagId;
+
+    public PlayerUpdatePacketRemoveEffectTagCompositeEffect() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(Guid);
+        writer.Write(TagId);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketRemoveEffectTagCompositeEffect.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketRemoveEffectTagCompositeEffect.cs
@@ -2,7 +2,6 @@ using Sanctuary.Core.IO;
 
 namespace Sanctuary.Packet;
 
-// op35 sub42 — stop a looping composite effect attached via sub41 (TagId must match).
 public class PlayerUpdatePacketRemoveEffectTagCompositeEffect : BasePlayerUpdatePacket, ISerializablePacket
 {
     public new const short OpCode = 42;

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketRemoveNotifications.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketRemoveNotifications.cs
@@ -4,28 +4,41 @@ using Sanctuary.Core.IO;
 
 namespace Sanctuary.Packet;
 
-public class PlayerUpdatePacketRemoveNotifications : ISerializablePacket
+public class PlayerUpdatePacketRemoveNotifications : BasePlayerUpdatePacket, ISerializablePacket
 {
-    public const short OpCode = 35;
-    public const short SubOpCode = 11;
+    public new const short OpCode = 11;
 
-    public List<ulong> Guids = new();
+    public class Entry : ISerializableType
+    {
+        public ulong Guid;
+
+        public int ThoughtBubbleIconId;
+
+        public int CompositeEffectId;
+
+        public void Serialize(PacketWriter writer)
+        {
+            writer.Write(Guid);
+
+            writer.Write(ThoughtBubbleIconId);
+
+            writer.Write(CompositeEffectId);
+        }
+    }
+
+    public List<Entry> Entries = [];
+
+    public PlayerUpdatePacketRemoveNotifications() : base(OpCode)
+    {
+    }
 
     public byte[] Serialize()
     {
         using var writer = new PacketWriter();
 
-        writer.Write(OpCode);
-        writer.Write(SubOpCode);
+        Write(writer);
 
-        writer.Write(Guids.Count);
-
-        foreach (var guid in Guids)
-        {
-            writer.Write(guid);
-            writer.Write(0);
-            writer.Write(0);
-        }
+        writer.Write(Entries);
 
         return writer.Buffer;
     }

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketRemoveNotifications.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketRemoveNotifications.cs
@@ -4,7 +4,6 @@ using Sanctuary.Core.IO;
 
 namespace Sanctuary.Packet;
 
-// op35 sub11 — clear overhead/minimap notification entries by guid.
 public class PlayerUpdatePacketRemoveNotifications : ISerializablePacket
 {
     public const short OpCode = 35;

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketRemoveNotifications.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketRemoveNotifications.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op35 sub11 — clear overhead/minimap notification entries by guid.
+public class PlayerUpdatePacketRemoveNotifications : ISerializablePacket
+{
+    public const short OpCode = 35;
+    public const short SubOpCode = 11;
+
+    public List<ulong> Guids = new();
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        writer.Write(OpCode);
+        writer.Write(SubOpCode);
+
+        writer.Write(Guids.Count);
+
+        foreach (var guid in Guids)
+        {
+            writer.Write(guid);
+            writer.Write(0);
+            writer.Write(0);
+        }
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketSetAnimation.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketSetAnimation.cs
@@ -2,9 +2,9 @@ using Sanctuary.Core.IO;
 
 namespace Sanctuary.Packet;
 
-public class PlayerUpdatePacketSetAnimation : : BasePlayerUpdatePacket, ISerializablePacket
+public class PlayerUpdatePacketSetAnimation : BasePlayerUpdatePacket, ISerializablePacket
 {
-    public const short OpCode = 8;
+    public new const short OpCode = 8;
 
     public ulong Guid;
     public int AnimationId;

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketSetAnimation.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketSetAnimation.cs
@@ -1,0 +1,31 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op35 sub8 — play an animation group on a character. AnimationId is an AnimationGroups.xml group id
+// (clip resolution is per-model via its .adr table).
+public class PlayerUpdatePacketSetAnimation : ISerializablePacket
+{
+    public const short OpCode = 35;
+    public const short SubOpCode = 8;
+
+    public ulong Guid;
+    public int AnimationId;
+    public int Unknown;
+    public byte PlayType = 2;
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        writer.Write(OpCode);
+        writer.Write(SubOpCode);
+
+        writer.Write(Guid);
+        writer.Write(AnimationId);
+        writer.Write(Unknown);
+        writer.Write(PlayType);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketSetAnimation.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketSetAnimation.cs
@@ -2,8 +2,6 @@ using Sanctuary.Core.IO;
 
 namespace Sanctuary.Packet;
 
-// op35 sub8 — play an animation group on a character. AnimationId is an AnimationGroups.xml group id
-// (clip resolution is per-model via its .adr table).
 public class PlayerUpdatePacketSetAnimation : ISerializablePacket
 {
     public const short OpCode = 35;

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketSetAnimation.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketSetAnimation.cs
@@ -2,22 +2,24 @@ using Sanctuary.Core.IO;
 
 namespace Sanctuary.Packet;
 
-public class PlayerUpdatePacketSetAnimation : ISerializablePacket
+public class PlayerUpdatePacketSetAnimation : : BasePlayerUpdatePacket, ISerializablePacket
 {
-    public const short OpCode = 35;
-    public const short SubOpCode = 8;
+    public const short OpCode = 8;
 
     public ulong Guid;
     public int AnimationId;
     public int Unknown;
     public byte PlayType = 2;
 
+    public PlayerUpdatePacketSetAnimation() : base(OpCode)
+    {
+    }
+
     public byte[] Serialize()
     {
         using var writer = new PacketWriter();
 
-        writer.Write(OpCode);
-        writer.Write(SubOpCode);
+        Write(writer);
 
         writer.Write(Guid);
         writer.Write(AnimationId);

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateCharacterState.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateCharacterState.cs
@@ -2,9 +2,6 @@ using Sanctuary.Core.IO;
 
 namespace Sanctuary.Packet;
 
-/// <summary>Character status bitfield (client ProxiedCharacter::m_nCharacterStatus). Several bits
-/// also halt the character's movement controller (Asleep/Rooted/Stunned/KnockedOut/KnockedBack/
-/// Frozen/Scripted).</summary>
 [System.Flags]
 public enum CharacterStatus
 {
@@ -28,8 +25,7 @@ public enum CharacterStatus
     IsPoppedUp = 0x100000,
 }
 
-// op35 sub20 — set a character's status bitfield. Regular NPCs ship Status=1 (IsNonAttackable);
-// bosses set IsBoss.
+
 public class PlayerUpdatePacketUpdateCharacterState : BasePlayerUpdatePacket, ISerializablePacket
 {
     public new const short OpCode = 20;

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateCharacterState.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateCharacterState.cs
@@ -1,0 +1,55 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+/// <summary>Character status bitfield (client ProxiedCharacter::m_nCharacterStatus). Several bits
+/// also halt the character's movement controller (Asleep/Rooted/Stunned/KnockedOut/KnockedBack/
+/// Frozen/Scripted).</summary>
+[System.Flags]
+public enum CharacterStatus
+{
+    None = 0,
+    IsNonAttackable = 0x1,
+    IsAfraid = 0x2,
+    IsAsleep = 0x4,
+    IsSilenced = 0x8,
+    IsBound = 0x10,
+    IsRooted = 0x20,
+    IsStunned = 0x40,
+    IsKnockedOut = 0x80,
+    IsNonAttackable2 = 0x100,
+    IsKnockedBack = 0x200,
+    IsConfused = 0x2000,
+    IsGoingHome = 0x4000,
+    IsBoss = 0x8000,
+    IsFrozen = 0x10000,
+    IsBerserk = 0x20000,
+    IsScriptedAnimation = 0x40000,
+    IsPoppedUp = 0x100000,
+}
+
+// op35 sub20 — set a character's status bitfield. Regular NPCs ship Status=1 (IsNonAttackable);
+// bosses set IsBoss.
+public class PlayerUpdatePacketUpdateCharacterState : BasePlayerUpdatePacket, ISerializablePacket
+{
+    public new const short OpCode = 20;
+
+    public ulong Guid;
+    public CharacterStatus Status;
+
+    public PlayerUpdatePacketUpdateCharacterState() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(Guid);
+        writer.Write((int)Status);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateDisposition.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateDisposition.cs
@@ -2,11 +2,6 @@ using Sanctuary.Core.IO;
 
 namespace Sanctuary.Packet;
 
-// op35 sub28 — per-NPC disposition override. The client's nameplate color resolver runs when
-// NameColor == 0 and colors the overhead name by disposition: 0 hostile = red, 1 neutral / 2 ally =
-// the bluish default. AddNpc's own Disposition field is ignored for this (the client derives it from
-// the encounter arena flag, defaulting to ally) — so send Disposition=0 after AddNpc to get a
-// red-named hostile.
 public class PlayerUpdatePacketUpdateDisposition : ISerializablePacket
 {
     public const short OpCode = 35;

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateDisposition.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateDisposition.cs
@@ -1,0 +1,30 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op35 sub28 — per-NPC disposition override. The client's nameplate color resolver runs when
+// NameColor == 0 and colors the overhead name by disposition: 0 hostile = red, 1 neutral / 2 ally =
+// the bluish default. AddNpc's own Disposition field is ignored for this (the client derives it from
+// the encounter arena flag, defaulting to ally) — so send Disposition=0 after AddNpc to get a
+// red-named hostile.
+public class PlayerUpdatePacketUpdateDisposition : ISerializablePacket
+{
+    public const short OpCode = 35;
+    public const short SubOpCode = 28;
+
+    public ulong Guid;
+    public int Disposition;
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        writer.Write(OpCode);
+        writer.Write(SubOpCode);
+
+        writer.Write(Guid);
+        writer.Write(Disposition);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateHitpoints.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateHitpoints.cs
@@ -2,9 +2,6 @@ using Sanctuary.Core.IO;
 
 namespace Sanctuary.Packet;
 
-// op35 sub5 — per-entity hitpoints update (drives an NPC's nameplate health bar), unlike
-// ClientUpdatePacketHitpoints (op38 sub1) which is self-only. The client reads all three ints;
-// current/max order is the working hypothesis.
 public class PlayerUpdatePacketUpdateHitpoints : BasePlayerUpdatePacket, ISerializablePacket
 {
     public new const short OpCode = 5;

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateHitpoints.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateHitpoints.cs
@@ -1,0 +1,36 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op35 sub5 — per-entity hitpoints update (drives an NPC's nameplate health bar), unlike
+// ClientUpdatePacketHitpoints (op38 sub1) which is self-only. The client reads all three ints;
+// current/max order is the working hypothesis.
+public class PlayerUpdatePacketUpdateHitpoints : BasePlayerUpdatePacket, ISerializablePacket
+{
+    public new const short OpCode = 5;
+
+    public ulong Guid;
+
+    public int Hitpoints;
+    public int MaxHitpoints;
+    public int Unknown;
+
+    public PlayerUpdatePacketUpdateHitpoints() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(Guid);
+
+        writer.Write(Hitpoints);
+        writer.Write(MaxHitpoints);
+        writer.Write(Unknown);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateMana.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateMana.cs
@@ -2,8 +2,6 @@ using Sanctuary.Core.IO;
 
 namespace Sanctuary.Packet;
 
-// op35 sub9 — per-NPC vitals push; the live server sent one to each encounter NPC right after its
-// AddNpc (values 100 / 800 / 800).
 public class PlayerUpdatePacketUpdateMana : BasePlayerUpdatePacket, ISerializablePacket
 {
     public new const short OpCode = 9;

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateMana.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateMana.cs
@@ -8,9 +8,9 @@ public class PlayerUpdatePacketUpdateMana : BasePlayerUpdatePacket, ISerializabl
 
     public ulong Guid;
 
-    public int Mana = 100;
-    public int Unknown2 = 800;
-    public int Unknown3 = 800;
+    public int BossMana = 100;
+    public int MaxMana = 800;
+    public int Mana = 800;
 
     public PlayerUpdatePacketUpdateMana() : base(OpCode)
     {

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateMana.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateMana.cs
@@ -23,9 +23,9 @@ public class PlayerUpdatePacketUpdateMana : BasePlayerUpdatePacket, ISerializabl
         Write(writer);
 
         writer.Write(Guid);
+        writer.Write(BossMana);
+        writer.Write(MaxMana);
         writer.Write(Mana);
-        writer.Write(Unknown2);
-        writer.Write(Unknown3);
 
         return writer.Buffer;
     }

--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateMana.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketUpdateMana.cs
@@ -1,0 +1,34 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op35 sub9 — per-NPC vitals push; the live server sent one to each encounter NPC right after its
+// AddNpc (values 100 / 800 / 800).
+public class PlayerUpdatePacketUpdateMana : BasePlayerUpdatePacket, ISerializablePacket
+{
+    public new const short OpCode = 9;
+
+    public ulong Guid;
+
+    public int Mana = 100;
+    public int Unknown2 = 800;
+    public int Unknown3 = 800;
+
+    public PlayerUpdatePacketUpdateMana() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(Guid);
+        writer.Write(Mana);
+        writer.Write(Unknown2);
+        writer.Write(Unknown3);
+
+        return writer.Buffer;
+    }
+}


### PR DESCRIPTION
Protocol groundwork for combat/encounter work — 10 new S2C PlayerUpdate (op35) serializers, reverse-engineered from the original client:

| Packet | Sub | What it's for |
|---|---|---|
| SetAnimation | 8 | Play an animation group on a character |
| HitPointModification | 35 | Floating damage/heal number + health-bar update |
| UpdateHitpoints | 5 | Per-NPC nameplate health bar |
| UpdateMana | 9 | Per-NPC vitals push |
| Knockback | 4 | Hurl an actor along a direction |
| RemoveNotifications | 11 | Clear overhead/minimap notification entries |
| AddEffectTagCompositeEffect | 41 | Attach a looping buff/debuff visual |
| RemoveEffectTagCompositeEffect | 42 | Stop it |
| UpdateCharacterState | 20 | Status bitfield (stun/sleep/boss/etc.) |
| UpdateDisposition | 28 | Per-NPC hostility — the red-name mechanism |

No behavior change — nothing in the server sends these yet. The encounter and combat code that uses them is coming in follow-up PRs, sliced small on purpose. This is part 1.

Pure additions, builds clean against main (Sanctuary.Packet only).