### PR TITLE
Fix AddNpc NameColor type: int ARGB, not float

### DIFF
--- a/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketAddNpc.cs
+++ b/src/Sanctuary.Packet/BasePlayerUpdatePacket/PlayerUpdatePacketAddNpc.cs
@@ -103,7 +103,9 @@ public class PlayerUpdatePacketAddNpc : BasePlayerUpdatePacket, ISerializablePac
     [JsonConverter(typeof(Vector4JsonConverter))]
     public Vector4 Tilt;
 
-    public float NameColor;
+    // ARGB int32 (client m_nNameColor) — a static nameplate color; 0 lets the client's disposition
+    // resolver pick the color.
+    public int NameColor;
 
     public int AreaDefinitionId;
 


### PR DESCRIPTION
The client reads AddNpc's NameColor as an int32 ARGB color (m_nNameColor); the float declaration mangles any assigned color through the int→float conversion. Both are 4 bytes on the wire and the only current assignment is `default`, so nothing breaks today — the field is just unusable.

Verified live: as an int, a static ARGB value colors the NPC's overhead nameplate as specified (tested red, purple, green). 0 keeps the client default.