### PR TITLE
Add encounter and minigame packet serializers

### DIFF
--- a/src/Sanctuary.Packet/BaseEncounterPacket.cs
+++ b/src/Sanctuary.Packet/BaseEncounterPacket.cs
@@ -20,5 +20,11 @@ public class BaseEncounterPacket
     {
         writer.Write(OpCode);
         writer.Write(SubOpCode);
+
+        // The client's encounter header reader expects these two ints — without them every encounter
+        // packet is 8 bytes short and gets rejected. (Encounter id / instance id; 0 works for global
+        // combat-state toggles.)
+        writer.Write(Unknown);
+        writer.Write(Unknown2);
     }
 }

--- a/src/Sanctuary.Packet/BaseEncounterPacket/EncounterDetailsResponsePacket.cs
+++ b/src/Sanctuary.Packet/BaseEncounterPacket/EncounterDetailsResponsePacket.cs
@@ -1,0 +1,181 @@
+using System.Collections.Generic;
+
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// One inline objective inside MiniGameInfo.ObjectiveData[]. Goals must be DEFINED here, inline in
+// the launch details packet, then ACTIVATED by id with op45 sub1 — the client's op45 dispatch
+// requires the goal id to already exist in the MiniGameState, so goals that aren't defined inline
+// can never be activated.
+public sealed class EncounterObjective
+{
+    public int ObjectiveId;
+    public int NameId;          // goal text (string id)
+    public int DescriptionId;
+    public int Status;          // 0 inline; ObjectiveActivate flips it to 2 (announce)
+    public int Count;
+    public int Total;           // 0 inline; the follow-up ObjectiveActivate sets the real total
+    public int Unknown8;
+    public bool MemberOnly;
+    public int Unknown10;
+}
+
+// op41 sub114 — the S2C encounter details packet: the adventure OFFER POPUP (title / difficulty /
+// description / prizes + GO! button) and, with the trailing Launch flag set, the LAUNCH that creates
+// the client's MiniGameState.
+//
+// Layout: BaseEncounter header, then EncounterDetailsCommon { ints, two empty collections,
+// ZoneContext, TeleportEffectId, flag bytes, RespawnTime, MiniGameInfo, two tail bytes }, then the
+// packet's own Launch flag, an int, and an empty StoreBundleId set.
+// MiniGameInfo: NameId · IconId · DescriptionId · Difficulty · ProfileType · Type · MembersOnly ·
+// RewardBundle ×3 (reward / member / preview) · ObjectiveData[] · byte ×5 · string · int · byte ·
+// PreselectedGameId · byte ×4 · ActivityId.
+public class EncounterDetailsResponsePacket : BaseEncounterPacket, ISerializablePacket
+{
+    public new const short OpCode = 114;
+
+    // --- the visible popup content (MiniGameInfo) ---
+    public int NameId;            // title (string id)
+    public int IconId = -1;       // dungeon emblem icon (-1 = none/default)
+    public int DescriptionId;     // description (string id)
+    public int Difficulty;
+    public int ProfileType;
+    public int MiniGameType;
+    public bool MembersOnly;
+
+    public int TeleportEffectId;
+    public int RespawnTime;
+    public bool Tutorial;
+
+    // Zone-context selector: 6 sets the client's ARENA flag — while set, every AddNpc apply forces
+    // the character's disposition to hostile before the nameplate color resolver runs, so encounter
+    // mobs get the RED name at spawn. 8 = hub. Send BEFORE the NPC adds.
+    public int ZoneContext;
+
+    // The trailing packet flag picks the client path: false = OFFER popup, true = LAUNCH (creates
+    // the MiniGameState from this packet's MiniGameInfo). The MiniGameState is the master gate for
+    // the whole minigame UI — every op45 objective packet is dropped while none exists — so the
+    // encounter entry flow must send this packet AGAIN with Launch=true at GO!.
+    public bool Launch;
+
+    // Objectives DEFINED inline (see EncounterObjective). Empty = count-0 (offer popup).
+    public List<EncounterObjective> Objectives = [];
+
+    // The offer popup's prize list + the victory loot-wheel slices — serialized into the PREVIEW
+    // reward bundle. The prize set should match the player's active job; ProfileType names the job
+    // CATEGORY the set is for.
+    public List<RewardEntry> PreviewRewards = [];
+
+    // Coins/XP for the extra loot-wheel slices (bundle coins/XP columns).
+    public int PreviewCoins;
+    public int PreviewXp;
+
+    // MiniGameInfo tail int = the ClientActivityDefinitions ACTIVITY ID for this encounter.
+    public int ActivityId;
+
+    public EncounterDetailsResponsePacket() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        // ===== EncounterDetailsCommon =====
+        writer.Write(0);                 // Unknown
+        writer.Write(0);                 // Unknown2
+        writer.Write(0);                 // collection count = 0
+        writer.Write(0);                 // EncounterTeamData list count = 0
+        writer.Write(ZoneContext);
+        writer.Write(TeleportEffectId);
+        writer.Write(true);              // Unknown5 (byte) — client ctor default 1
+        writer.Write(false);             // Unknown6 (byte)
+        writer.Write(Tutorial);          // (byte)
+        writer.Write(0);                 // Unknown8
+        writer.Write(RespawnTime);
+
+        // ----- MiniGameInfo -----
+        writer.Write(NameId);
+        writer.Write(IconId);
+        writer.Write(DescriptionId);
+        writer.Write(Difficulty);
+        writer.Write(ProfileType);
+        writer.Write(MiniGameType);
+        writer.Write(MembersOnly);       // (byte)
+        WriteEmptyRewardBundle(writer);  // reward bundle
+        WriteEmptyRewardBundle(writer);  // member reward bundle
+        WriteRewardBundle(writer, PreviewRewards, PreviewCoins, PreviewXp); // preview (popup prizes + loot wheel)
+        writer.Write(Objectives.Count);
+        foreach (var obj in Objectives)
+            WriteObjective(writer, obj);
+        writer.Write(true);              // U8  (client ctor default 1)
+        writer.Write(true);              // U9
+        writer.Write(true);              // U10
+        writer.Write(true);              // U11
+        writer.Write(true);              // U12
+        writer.Write((string?)null);     // U13 string
+        writer.Write(1);                 // U14 (client ctor default 1)
+        writer.Write(true);              // U15 (client ctor default 1)
+        writer.Write(0);                 // PreselectedGameId
+        writer.Write(false);             // U16
+        writer.Write(false);             // U17
+        writer.Write(false);             // U18
+        writer.Write(false);             // U19
+        writer.Write(ActivityId);
+        // ----- end MiniGameInfo -----
+
+        writer.Write(false);             // UNK0 (byte)
+        writer.Write(true);              // UNK1 (byte) — REQUIRED: the client gates the whole popup on this
+        // ===== end EncounterDetailsCommon =====
+
+        writer.Write(Launch);            // (byte): false = offer popup, true = launch
+        writer.Write(0);                 // packet Unknown
+        writer.Write(0);                 // StoreBundleId set count = 0
+
+        return writer.Buffer;
+    }
+
+    // One ObjectiveData record — byte-identical to the op45 ObjectiveData layout so an
+    // inline-defined goal can be activated by id.
+    private static void WriteObjective(PacketWriter writer, EncounterObjective obj)
+    {
+        writer.Write(obj.ObjectiveId);
+        writer.Write(obj.NameId);
+        writer.Write(obj.DescriptionId);
+        writer.Write(false);              // byte Unknown4
+        WriteEmptyRewardBundle(writer);
+        writer.Write(obj.Status);
+        writer.Write(obj.Count);
+        writer.Write(obj.Total);
+        writer.Write(obj.Unknown8);
+        writer.Write(obj.MemberOnly);     // (byte)
+        writer.Write(obj.Unknown10);
+    }
+
+    // RewardBundleBase with no entries — 69 fixed bytes; all-zero is a valid empty bundle.
+    private static void WriteEmptyRewardBundle(PacketWriter writer)
+    {
+        writer.Write(false);
+        for (var i = 0; i < 9; i++) writer.Write(0);
+        writer.Write(0); writer.Write(0);
+        writer.Write(0); writer.Write(0);
+        writer.Write(0);
+        writer.Write(0);
+        writer.Write(0);                                  // entryCount = 0
+        writer.Write(0);
+    }
+
+    private static void WriteRewardBundle(PacketWriter writer, List<RewardEntry> entries, int coins, int xp)
+    {
+        if (entries.Count == 0)
+        {
+            WriteEmptyRewardBundle(writer);
+            return;
+        }
+
+        RewardBundle.Write(writer, entries, coins, xp, entries[0].IconId, entries[0].NameId);
+    }
+}

--- a/src/Sanctuary.Packet/BaseEncounterPacket/EncounterPacketIsFighting.cs
+++ b/src/Sanctuary.Packet/BaseEncounterPacket/EncounterPacketIsFighting.cs
@@ -1,0 +1,27 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op41 sub133 — client BaseClient::SetIsFighting. Together with sub132 (EncounterOverworldCombatPacket)
+// this opens the client-side gate that otherwise suppresses floating combat text (damage numbers, MISS!).
+public class EncounterPacketIsFighting : BaseEncounterPacket, ISerializablePacket
+{
+    public new const short OpCode = 133;
+
+    public bool InWorldCombat;
+
+    public EncounterPacketIsFighting() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(InWorldCombat);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseEncounterPacket/EncounterPacketPlayerEnter.cs
+++ b/src/Sanctuary.Packet/BaseEncounterPacket/EncounterPacketPlayerEnter.cs
@@ -1,0 +1,32 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op41 sub2 — marks the player entered into a launched encounter. This is what makes the client render
+// the minigame HUD (goals panel, timer): creating the MiniGameState via the launch details packet is
+// necessary but NOT sufficient — without this packet the HUD never shows.
+public class EncounterPacketPlayerEnter : ISerializablePacket
+{
+    public const short OpCode = 41;
+    public const short SubOpCode = 2;
+
+    public int EncounterId;
+    public int InstanceId;
+    public ulong PlayerGuid;
+    public byte Unknown;
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        writer.Write(OpCode);
+        writer.Write(SubOpCode);
+
+        writer.Write(EncounterId);
+        writer.Write(InstanceId);
+        writer.Write(PlayerGuid);
+        writer.Write(Unknown);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseEncounterPacket/EncounterStatePacket.cs
+++ b/src/Sanctuary.Packet/BaseEncounterPacket/EncounterStatePacket.cs
@@ -1,0 +1,30 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op41 sub106 — encounter state machine step. The server walks State through the entry flow (same
+// EncounterId/InstanceId as the details packet header): 2 offer shown → 3 → 4 ready → 5 after GO! →
+// 6 running.
+public class EncounterStatePacket : ISerializablePacket
+{
+    public const short OpCode = 41;
+    public const short SubOpCode = 106;
+
+    public int EncounterId;
+    public int InstanceId;
+    public int State;
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        writer.Write(OpCode);
+        writer.Write(SubOpCode);
+
+        writer.Write(EncounterId);
+        writer.Write(InstanceId);
+        writer.Write(State);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseEncounterPacket/EncounterZoneIsReadyPacket.cs
+++ b/src/Sanctuary.Packet/BaseEncounterPacket/EncounterZoneIsReadyPacket.cs
@@ -1,0 +1,24 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op41 sub107 (S2C) — flips the encounter offer popup's loading spinner into the green GO! button
+// ("MiniGame:SetMiniGameReady"). The body is JUST the 12-byte encounter header: the client validator
+// requires zero leftover bytes, so any extra payload gets the packet silently rejected.
+public class EncounterZoneIsReadyPacket : BaseEncounterPacket, ISerializablePacket
+{
+    public new const short OpCode = 107;
+
+    public EncounterZoneIsReadyPacket() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer); // the header is the entire packet
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseMiniGamePacket.cs
+++ b/src/Sanctuary.Packet/BaseMiniGamePacket.cs
@@ -1,0 +1,35 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op39 — the minigame lifecycle family. Header: [short op39][byte subOpCode][int StateId][int GroupId]
+// [int GameId]. Note the sub-opcode is a single BYTE (op41's is a short).
+public class BaseMiniGamePacket
+{
+    public const short OpCode = 39;
+
+    private byte SubOpCode;
+
+    public int StateId;
+    public int GroupId;
+    public int GameId;
+
+    public BaseMiniGamePacket(byte subOpCode, int stateId, int groupId, int gameId)
+    {
+        SubOpCode = subOpCode;
+
+        StateId = stateId;
+        GroupId = groupId;
+        GameId = gameId;
+    }
+
+    public virtual void Write(PacketWriter writer)
+    {
+        writer.Write(OpCode);
+        writer.Write(SubOpCode);
+
+        writer.Write(StateId);
+        writer.Write(GroupId);
+        writer.Write(GameId);
+    }
+}

--- a/src/Sanctuary.Packet/BaseMiniGamePacket/MiniGameGameOverPacket.cs
+++ b/src/Sanctuary.Packet/BaseMiniGamePacket/MiniGameGameOverPacket.cs
@@ -1,0 +1,36 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op39 sub18 — the minigame/encounter ended and whether the player WON. This is what flips the
+// end-of-game card between the win presentation and "TRY AGAIN!" — without it the state's Won flag
+// stays false and the failure card shows even after a victory. StateId -1 = matches every state.
+public class MiniGameGameOverPacket : BaseMiniGamePacket, ISerializablePacket
+{
+    public new const byte OpCode = 18;
+
+    public bool Won;
+    public int Unknown1;      // client default 0
+    public int Unknown2;      // client default 0
+    public int Unknown3 = 1;  // client default 1
+
+    public MiniGameGameOverPacket(bool won, int stateId = -1, int groupId = -1, int gameId = -1)
+        : base(OpCode, stateId, groupId, gameId)
+    {
+        Won = won;
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(Won);
+        writer.Write(Unknown1);
+        writer.Write(Unknown2);
+        writer.Write(Unknown3);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseMiniGamePacket/MiniGameGameStartPacket.cs
+++ b/src/Sanctuary.Packet/BaseMiniGamePacket/MiniGameGameStartPacket.cs
@@ -1,0 +1,22 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op39 sub17 — S2C ack for a client MiniGameStartGame (sub5) request, echoing StateId/GroupId/GameId.
+public class MiniGameGameStartPacket : BaseMiniGamePacket, ISerializablePacket
+{
+    public new const byte OpCode = 17;
+
+    public MiniGameGameStartPacket(int stateId, int groupId, int gameId) : base(OpCode, stateId, groupId, gameId)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseMiniGamePacket/MiniGameKnockOutPacket.cs
+++ b/src/Sanctuary.Packet/BaseMiniGamePacket/MiniGameKnockOutPacket.cs
@@ -1,0 +1,34 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op39 sub23 — knockout counter/limit. Drives the combat-minigame HUD's knockout display, which
+// renders MaxKnockouts - CurrentKnockouts as "remaining". Base ids are -1: the counter is
+// whole-team, not per-state.
+public class MiniGameKnockOutPacket : BaseMiniGamePacket, ISerializablePacket
+{
+    public new const byte OpCode = 23;
+
+    public int CurrentKnockouts;
+    public int MaxKnockouts;
+
+    public MiniGameKnockOutPacket(int currentKnockouts, int maxKnockouts,
+        int stateId = -1, int groupId = -1, int gameId = -1)
+        : base(OpCode, stateId, groupId, gameId)
+    {
+        CurrentKnockouts = currentKnockouts;
+        MaxKnockouts = maxKnockouts;
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(CurrentKnockouts);
+        writer.Write(MaxKnockouts);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseMiniGamePacket/MiniGameLootWheelPackets.cs
+++ b/src/Sanctuary.Packet/BaseMiniGamePacket/MiniGameLootWheelPackets.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// The victory-screen loot wheel flow:
+//   1) S2C op39 sub45 (this packet) — base header + one RewardBundle. The client matches the bundle's
+//      first entry's NameId against the stored PREVIEW bundle rows; the matching row becomes the
+//      wheel's landing slice. No entry: Coins > 0 lands on the coins slice. The spin animation is
+//      pure theater — the outcome is whatever this packet says.
+//   2) The player clicks spin; the wheel animates to the stored slice.
+//   3) C2S op39 sub46 (base header only) — the client reports the wheel stopped; the server grants
+//      the prize.
+public class MiniGameLootWheelSetItemToLandOnPacket : BaseMiniGamePacket, ISerializablePacket
+{
+    public new const byte OpCode = 45;
+
+    /// <summary>The landed prize (single entry; only NameId matters for slice selection).
+    /// Leave empty and set Coins to land on the coins slice.</summary>
+    public List<RewardEntry> Entries = [];
+
+    public int Coins;
+
+    public int Unknown15 = 957; // constant across observed wheel bundles
+
+    public MiniGameLootWheelSetItemToLandOnPacket() : base(OpCode, -1, -1, -1)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer); // all -1 = "current state"
+
+        var iconOverride = Entries.Count > 0 ? Entries[0].IconId : -1;
+        var nameOverride = Entries.Count > 0 ? Entries[0].NameId : -1;
+        RewardBundle.Write(writer, Entries, Coins, 0, iconOverride, nameOverride, Unknown15);
+
+        return writer.Buffer;
+    }
+}
+
+public sealed class MiniGameScoreRow
+{
+    public string Name = "";    // client string key, e.g. "scoreEnemiesDefeated"
+    public int NameId = -1;     // -1 = the string key carries the label
+    public int Order;           // display order: 0 enemies, 2 time bonus, 3 knockouts, 4 total
+    public int Value = -1;      // e.g. enemies defeated; -1 = none (total row)
+    public int Max = -1;        // e.g. knockouts 5 of Max 5; -1 = no max
+    public int Points;          // score contribution shown right-aligned
+}
+
+// S2C op39 sub47 — the victory screen's score rows. Per row:
+// [i32 len][ascii name][i32 NameId][i32 Order][i32 Value][i32 Max][i32 Points].
+// The client appends its own scoreObjectives/scoreBonusObjectives rows from the MiniGameState.
+public class MiniGameGameEndScorePacket : BaseMiniGamePacket, ISerializablePacket
+{
+    public new const byte OpCode = 47;
+
+    public List<MiniGameScoreRow> Rows = [];
+
+    public MiniGameGameEndScorePacket() : base(OpCode, -1, -1, -1)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(Rows.Count);
+        foreach (var row in Rows)
+        {
+            writer.Write(row.Name);
+            writer.Write(row.NameId);
+            writer.Write(row.Order);
+            writer.Write(row.Value);
+            writer.Write(row.Max);
+            writer.Write(row.Points);
+        }
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseMiniGamePacket/MiniGameStateRemovePacket.cs
+++ b/src/Sanctuary.Packet/BaseMiniGamePacket/MiniGameStateRemovePacket.cs
@@ -1,0 +1,26 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op39 sub19 — server-driven minigame state removal. Performs the full client-side teardown that
+// otherwise only happens when the player clicks leave: hides the minigame UI, removes the
+// MiniGameState, and (for combat-type games) exits combat mode. Without this the client stays "in
+// the game" forever after an encounter ends. StateId <= 0 targets the first state.
+public class MiniGameStateRemovePacket : BaseMiniGamePacket, ISerializablePacket
+{
+    public new const byte OpCode = 19;
+
+    public MiniGameStateRemovePacket(int stateId = 0, int groupId = -1, int gameId = -1)
+        : base(OpCode, stateId, groupId, gameId)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseObjectivePacket/ObjectivePackets.cs
+++ b/src/Sanctuary.Packet/BaseObjectivePacket/ObjectivePackets.cs
@@ -1,0 +1,77 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// Minigame goal state — opcode 45, header [int16 45][byte subOpCode]. A MiniGameState must exist
+// client-side (created by the launch details packet) and goals must be DEFINED inline in that
+// packet's ObjectiveData[]: the client drops op45 packets for goal ids it doesn't already know.
+// sub1 activates a goal, sub2 ticks progress, sub3 completes it.
+public static class ObjectivePacketWriter
+{
+    public const short OpCode = 45;
+}
+
+/// <summary>Sub 1 — (re)activate a goal: sets its Total and fires the "New Objective" announce.</summary>
+public class ObjectiveActivatePacket : ISerializablePacket
+{
+    public const byte SubOpCode = 1;
+
+    public int ObjectiveId;
+    public int Total;
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        writer.Write(ObjectivePacketWriter.OpCode);
+        writer.Write(SubOpCode);
+        writer.Write(ObjectiveId);
+        writer.Write(Total);
+
+        return writer.Buffer;
+    }
+}
+
+/// <summary>Sub 3 — complete a goal: fires the green-check "Goal Complete!" announce for the id.</summary>
+public class ObjectiveCompletePacket : ISerializablePacket
+{
+    public const byte SubOpCode = 3;
+
+    public int ObjectiveId;
+    public int Unknown;
+    public int Unknown2 = 5000;
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        writer.Write(ObjectivePacketWriter.OpCode);
+        writer.Write(SubOpCode);
+        writer.Write(ObjectiveId);
+        writer.Write(Unknown);
+        writer.Write(Unknown2);
+
+        return writer.Buffer;
+    }
+}
+
+/// <summary>Sub 2 — progress tick: sets the goal's current Count.</summary>
+public class ObjectiveUpdatePacket : ISerializablePacket
+{
+    public const byte SubOpCode = 2;
+
+    public int ObjectiveId;
+    public int Count;
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        writer.Write(ObjectivePacketWriter.OpCode);
+        writer.Write(SubOpCode);
+        writer.Write(ObjectiveId);
+        writer.Write(Count);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseUiPacket/UiObjectivePackets.cs
+++ b/src/Sanctuary.Packet/BaseUiPacket/UiObjectivePackets.cs
@@ -1,0 +1,85 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// The in-game top-right "Goals" window is fed exclusively by this op47 family (the op45 minigame
+// goal state drives the lobby panes and announces instead). sub1 adds/updates a row, sub3
+// completes/removes it, sub5 clears the window. No minigame state is required — the window works
+// standalone and shows itself on its first row.
+public class UiObjectiveAddPacket : BaseUiPacket, ISerializablePacket
+{
+    public new const byte OpCode = 1;
+
+    public int ObjectiveId;
+    public int Unknown2;
+    public int NameId;          // row text (string id)
+    public bool Unknown4;
+    public bool MembersOnly;    // non-member client: text swaps to the members-only string, icon locked
+    public int Unknown6;
+    public bool Unknown7;
+    public int Unknown8 = 1;
+
+    public UiObjectiveAddPacket() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(ObjectiveId);
+        writer.Write(Unknown2);
+        writer.Write(NameId);
+        writer.Write(Unknown4);
+        writer.Write(MembersOnly);
+        writer.Write(Unknown6);
+        writer.Write(Unknown7);
+        writer.Write(Unknown8);
+
+        return writer.Buffer;
+    }
+}
+
+/// <summary>Sub 3 — complete/remove a Goals-window row by objective id.</summary>
+public class UiObjectiveCompletePacket : BaseUiPacket, ISerializablePacket
+{
+    public new const byte OpCode = 3;
+
+    public int ObjectiveId;
+
+    public UiObjectiveCompletePacket() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        writer.Write(ObjectiveId);
+
+        return writer.Buffer;
+    }
+}
+
+/// <summary>Sub 5 — clear every Goals-window row (no payload).</summary>
+public class UiObjectiveClearPacket : BaseUiPacket, ISerializablePacket
+{
+    public new const byte OpCode = 5;
+
+    public UiObjectiveClearPacket() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/PacketEncounterDataCommon.cs
+++ b/src/Sanctuary.Packet/PacketEncounterDataCommon.cs
@@ -1,0 +1,95 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// S2C opcode 62 — the combat RULESET. The client applies it in one shot:
+//   CanUseAbilities/CanUseConsumables -> shows/hides the action bar
+//   UseCombatCamera + CombatType      -> combat camera + controller
+//   ShowHpBar                         -> NPC health bars (mode-wide)
+//   ShowCombatUi                      -> combat player/party frames
+//   CombatType                        -> BaseClient::InCombat() == true (blocks job changes etc.)
+// The server must push combat rules ON at encounter start and push the DEFAULTS back at exit, or
+// the client stays in combat forever.
+public class PacketEncounterDataCommon : ISerializablePacket
+{
+    public const short OpCode = 62;
+
+    public bool CombatStance;
+    public bool CanTakeDamage;
+    public bool CanUseAbilities;
+    public bool CanUseConsumables;
+    public bool CanMelee;
+    public bool CanUseTraits;
+    public bool CanChangeMaxMoveSpeed;
+    public bool ShowHpBar;
+    public bool ShowCombatUi;
+    public bool UseCombatCamera;
+    public bool CombatType;
+
+    public int GameTimeOverride = -1;
+    public float ObjectiveMultiplier = 1f;
+    public int QuickCompletionTime = 3600;
+    public int QuickCompletionValue;
+    public int QuickCompletionLoss;
+    public int NpcKOValue;
+    public int KnockoutRewardValue;
+    public int KnockoutPenalty;
+
+    /// <summary>The combat-encounter ruleset: everything enabled, with the score values a live
+    /// combat encounter used (300/NPC, 25000 per knockout remaining, 5000 penalty).</summary>
+    public static PacketEncounterDataCommon CreateCombatRules() => new()
+    {
+        CombatStance = true,
+        CanTakeDamage = true,
+        CanUseAbilities = true,
+        CanUseConsumables = true,
+        CanMelee = true,
+        CanUseTraits = true,
+        CanChangeMaxMoveSpeed = true,
+        ShowHpBar = true,
+        ShowCombatUi = true,
+        UseCombatCamera = true,
+        CombatType = true,
+
+        ObjectiveMultiplier = 500f,
+        QuickCompletionTime = 1,
+        QuickCompletionValue = 100_000,
+        QuickCompletionLoss = 500,
+        NpcKOValue = 300,
+        KnockoutRewardValue = 25_000,
+        KnockoutPenalty = 5_000,
+    };
+
+    /// <summary>The out-of-encounter defaults (matches the client constructor) — releases combat mode.</summary>
+    public static PacketEncounterDataCommon CreateDefault() => new();
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        writer.Write(OpCode);
+
+        writer.Write(CombatStance);
+        writer.Write(CanTakeDamage);
+        writer.Write(CanUseAbilities);
+        writer.Write(CanUseConsumables);
+        writer.Write(CanMelee);
+        writer.Write(CanUseTraits);
+        writer.Write(CanChangeMaxMoveSpeed);
+        writer.Write(ShowHpBar);
+        writer.Write(ShowCombatUi);
+        writer.Write(UseCombatCamera);
+        writer.Write(CombatType);
+
+        writer.Write(GameTimeOverride);
+        writer.Write(ObjectiveMultiplier);
+        writer.Write(QuickCompletionTime);
+        writer.Write(QuickCompletionValue);
+        writer.Write(QuickCompletionLoss);
+        writer.Write(NpcKOValue);
+        writer.Write(KnockoutRewardValue);
+        writer.Write(KnockoutPenalty);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/RewardBundle.cs
+++ b/src/Sanctuary.Packet/RewardBundle.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// One prize row inside a RewardBundle. The client surfaces these in two places, both fed from the
+// same preview bundle: the encounter offer popup's prize list (up to 4 non-hidden rows) and the
+// victory screen's loot-wheel slices (hidden rows still render as slices).
+public sealed class RewardEntry
+{
+    public int Type = 1;        // 1 = ITEM
+    public bool Hidden;
+    public int IconId;          // ClientItemDefinitions Icon.Id
+    public int TintId;          // ClientItemDefinitions Icon.TintId
+    public int NameId;          // item name string id
+    public int Quantity = 1;
+    public int ItemDefId;       // wire Param1 = the ClientItemDefinitions item id
+    public int Param2;
+
+    /// <summary>Optional per-entry inventory item guid tail (the player's item row id, not the def
+    /// id). The bundle's lead byte gates these for every entry at once.</summary>
+    public int? TailItemGuid;
+}
+
+// Shared RewardBundleBase serializer:
+//   byte U1 ("entries carry ItemGuid tails") · int32 ×9 (U2 = coins, U3 = XP, U8 = 1.0f) ·
+//   int32 ×4 (two id pairs) · int32 U13 (icon override; -1 = defer to entry[0]) · int32 U14 (name
+//   override; -1 = entry[0]) · int32 entryCount · entries · int32 U15.
+//   Entry: int32 type · byte Hidden · int32 IconId · int32 TintId · int32 NameId · int32 Quantity ·
+//   int32 Param1 (item def id) · int32 Param2 · string · int32 text color · byte members-only ·
+//   [int32 ItemGuid iff bundle U1].
+public static class RewardBundle
+{
+    public static void Write(PacketWriter writer, IReadOnlyList<RewardEntry> entries,
+        int coins = 0, int xp = 0, int iconOverride = -1, int nameOverride = -1, int unknown15 = 0)
+    {
+        var tails = entries.Any(e => e.TailItemGuid.HasValue);
+
+        writer.Write(tails);
+        writer.Write(coins);
+        writer.Write(xp);
+        writer.Write(0);
+        writer.Write(0);
+        writer.Write(0);
+        writer.Write(0);
+        writer.Write(1.0f);
+        writer.Write(0);
+        writer.Write(0);
+        writer.Write(0); writer.Write(0);
+        writer.Write(0); writer.Write(0);
+        writer.Write(iconOverride);
+        writer.Write(nameOverride);
+        writer.Write(entries.Count);
+        foreach (var e in entries)
+        {
+            writer.Write(e.Type);
+            writer.Write(e.Hidden);
+            writer.Write(e.IconId);
+            writer.Write(e.TintId);
+            writer.Write(e.NameId);
+            writer.Write(e.Quantity);
+            writer.Write(e.ItemDefId);
+            writer.Write(e.Param2);
+            writer.Write((string?)null);
+            writer.Write(0);              // item text color (0 = default)
+            writer.Write(false);          // members only
+            if (tails)
+                writer.Write(e.TailItemGuid ?? 0);
+        }
+        writer.Write(unknown15);
+    }
+}

--- a/src/Sanctuary.Packet/RewardBundlePacket.cs
+++ b/src/Sanctuary.Packet/RewardBundlePacket.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op50 sub1 — standalone reward-grant banner, sent right after the loot wheel stops. Two shapes:
+// a CONTENTS grant (entries list, e.g. the items inside an opened pack) or a PRIZE banner
+// (no entries, IconId/NameId = the won prize — the "you won X" display).
+public class RewardBundlePacket : ISerializablePacket
+{
+    public const short OpCode = 50;
+    public const byte SubOpCode = 1;
+
+    public List<RewardEntry> Entries = [];
+
+    public int Coins;
+    public int Xp;
+
+    /// <summary>Banner icon/name (-1 = defer to entry[0]).</summary>
+    public int IconId = -1;
+    public int NameId = -1;
+
+    public int Unknown15;
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        writer.Write(OpCode);
+        writer.Write(SubOpCode);
+
+        RewardBundle.Write(writer, Entries, Coins, Xp, IconId, NameId, Unknown15);
+
+        return writer.Buffer;
+    }
+}


### PR DESCRIPTION
The wire protocol for combat encounters and minigames, reverse-engineered from the original client:

**Encounter family (op41):**
| Packet | Sub | What it's for |
|---|---|---|
| EncounterDetailsResponse | 114 | The adventure offer popup (title/prizes/goals) and, with its Launch flag, the client MiniGameState creation |
| EncounterState | 106 | Entry-flow state machine (offer → ready → GO! → running) |
| EncounterZoneIsReady | 107 | Flips the offer popup's spinner into the green GO! button |
| EncounterPacketPlayerEnter | 2 | Makes the client render the minigame HUD (goals panel) |
| EncounterPacketIsFighting | 133 | Opens the floating-combat-text gate (damage numbers) |

**Minigame family (op39):** GameStart (17), GameOver won/lost (18), StateRemove teardown (19), KnockOut counter (23), loot-wheel landing slice (45), victory score rows (47).

**Plus:** op45 goal activate/update/complete, op47 Goals-window rows, op62 combat ruleset (health bars, combat camera, ability-bar gating), and the shared RewardBundle serializer (op50 grant banner included).

**One fix to an existing file:** `BaseEncounterPacket.Write` declared two header ints the client requires but never wrote them, leaving every encounter packet 8 bytes short and rejected client-side.

Nothing sends these yet — the encounter zone and handlers come in follow-up PRs. Part 3, after #74 and #75.