### PR TITLE
Add ability and combat packet serializers

### DIFF
--- a/src/Sanctuary.Packet.Common/Ability.cs
+++ b/src/Sanctuary.Packet.Common/Ability.cs
@@ -9,17 +9,27 @@ public class Ability : ISerializableType
     // 2 - Item
     // 3 - AbilityDefinition
     public int Type;
+
     public int Unknown2;
+
     public int ManaCost;
+
     public int ItemDefinitionId;
+
     public int IconId;
     public int NameId;
+
     public int Unknown7;
     public int Unknown8;
     public int Unknown9;
+
     public int AbilityDefinitionId;
+
     public int Unknown11;
-    public bool Unknown12;
+
+    public bool ForceDismount;
+
+    public static Ability Empty = new();
 
     public void Serialize(PacketWriter writer)
     {
@@ -40,11 +50,15 @@ public class Ability : ISerializableType
 
         writer.Write(IconId);
         writer.Write(NameId);
+
         writer.Write(Unknown7);
         writer.Write(Unknown8);
         writer.Write(Unknown9);
+
         writer.Write(AbilityDefinitionId);
+
         writer.Write(Unknown11);
-        writer.Write(Unknown12);
+
+        writer.Write(ForceDismount);
     }
 }

--- a/src/Sanctuary.Packet.Common/AbilitySet.cs
+++ b/src/Sanctuary.Packet.Common/AbilitySet.cs
@@ -1,0 +1,22 @@
+﻿using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet.Common;
+
+public class AbilitySet : ISerializableType
+{
+    // Hardcoded in the client.
+    private const int MaxAbilitySlots = 8;
+
+    public Ability[] Abilities = new Ability[MaxAbilitySlots];
+
+    public AbilitySet()
+    {
+        for (var i = 0; i < MaxAbilitySlots; i++)
+            Abilities[i] = Ability.Empty;
+    }
+
+    public void Serialize(PacketWriter writer)
+    {
+        writer.Write(Abilities);
+    }
+}

--- a/src/Sanctuary.Packet.Common/ClientPcProfile.cs
+++ b/src/Sanctuary.Packet.Common/ClientPcProfile.cs
@@ -34,17 +34,7 @@ public class ClientPcProfile : ISerializableType
 
     public int Unknown21;
 
-    public List<Ability> Abilities = new()
-    {
-        new Ability(),
-        new Ability(),
-        new Ability(),
-        new Ability(),
-        new Ability(),
-        new Ability(),
-        new Ability(),
-        new Ability()
-    };
+    public AbilitySet AbilitySet = new();
 
     public List<AbilityExperience> AbilityExperiences = new()
     {
@@ -81,7 +71,7 @@ public class ClientPcProfile : ISerializableType
 
         writer.Write(Unknown21);
 
-        writer.Write(Abilities);
+        AbilitySet.Serialize(writer);
 
         foreach (var abilityExperience in AbilityExperiences)
         {

--- a/src/Sanctuary.Packet/BaseAbilityPacket/AbilityPacketSetDefinition.cs
+++ b/src/Sanctuary.Packet/BaseAbilityPacket/AbilityPacketSetDefinition.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op36 sub5 — populates a profile's ability toolbar (the on-screen 1/2/3/4 keys = slots 0-3).
+// Wire: [int16 36][int16 5][int32 ProfileId][int32 SlotCount][Slot × SlotCount].
+// Slots are POSITIONAL (list index = key position) and the client renders them as a contiguous run
+// from slot 0 — an empty slot hides everything after it. ProfileId must be the player's current
+// active profile or the packet is ignored.
+public class AbilityPacketSetDefinition : BaseAbilityPacket, ISerializablePacket
+{
+    public new const short OpCode = 5;
+
+    public class Slot
+    {
+        public int Type = 3;          // 0 empty, 1/3 ability (AbilityDefinition), 2 item
+        public int Unknown2;
+        public int ManaCost;          // the client greys the slot out while current energy is below this
+        public int ItemDefinitionId;  // Type 2 only
+        public int IconId;
+        public int NameId;
+        public int Unknown7 = 4;
+        public float Unknown8;
+        public int Unknown9 = 1;
+        public int AbilityDefinitionId;
+        public int Unknown11;
+        public bool Unknown12 = true;
+
+        public void Serialize(PacketWriter writer)
+        {
+            writer.Write(Type);
+
+            if (Type == 0)
+                return;
+
+            if (Type == 1 || Type == 3)
+            {
+                writer.Write(Unknown2);
+                writer.Write(ManaCost);
+            }
+            else if (Type == 2)
+            {
+                writer.Write(ItemDefinitionId);
+            }
+
+            writer.Write(IconId);
+            writer.Write(NameId);
+            writer.Write(Unknown7);
+            writer.Write(Unknown8);
+            writer.Write(Unknown9);
+            writer.Write(AbilityDefinitionId);
+            writer.Write(Unknown11);
+            writer.Write(Unknown12);
+        }
+    }
+
+    public int ProfileId;
+    public int SlotCount = 8;
+    public List<Slot?> Slots = new();
+
+    public AbilityPacketSetDefinition() : base(OpCode)
+    {
+    }
+
+    /// <summary>An all-empty toolbar (8 Type-0 slots).</summary>
+    public static AbilityPacketSetDefinition CreateEmpty(int profileId)
+    {
+        return new AbilityPacketSetDefinition { ProfileId = profileId, SlotCount = 8 };
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        base.Write(writer);
+
+        writer.Write(ProfileId);
+        writer.Write(SlotCount);
+
+        for (var i = 0; i < SlotCount; i++)
+        {
+            if (i < Slots.Count && Slots[i] is { } slot)
+                slot.Serialize(writer);
+            else
+                writer.Write(0); // empty slot (Type = 0)
+        }
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseAbilityPacket/AbilityPacketSetDefinition.cs
+++ b/src/Sanctuary.Packet/BaseAbilityPacket/AbilityPacketSetDefinition.cs
@@ -1,6 +1,5 @@
-using System.Collections.Generic;
-
 using Sanctuary.Core.IO;
+using Sanctuary.Packet.Common;
 
 namespace Sanctuary.Packet;
 
@@ -13,52 +12,9 @@ public class AbilityPacketSetDefinition : BaseAbilityPacket, ISerializablePacket
 {
     public new const short OpCode = 5;
 
-    public class Slot
-    {
-        public int Type = 3;          // 0 empty, 1/3 ability (AbilityDefinition), 2 item
-        public int Unknown2;
-        public int ManaCost;          // the client greys the slot out while current energy is below this
-        public int ItemDefinitionId;  // Type 2 only
-        public int IconId;
-        public int NameId;
-        public int Unknown7 = 4;
-        public float Unknown8;
-        public int Unknown9 = 1;
-        public int AbilityDefinitionId;
-        public int Unknown11;
-        public bool Unknown12 = true;
-
-        public void Serialize(PacketWriter writer)
-        {
-            writer.Write(Type);
-
-            if (Type == 0)
-                return;
-
-            if (Type == 1 || Type == 3)
-            {
-                writer.Write(Unknown2);
-                writer.Write(ManaCost);
-            }
-            else if (Type == 2)
-            {
-                writer.Write(ItemDefinitionId);
-            }
-
-            writer.Write(IconId);
-            writer.Write(NameId);
-            writer.Write(Unknown7);
-            writer.Write(Unknown8);
-            writer.Write(Unknown9);
-            writer.Write(AbilityDefinitionId);
-            writer.Write(Unknown11);
-            writer.Write(Unknown12);
-        }
-    }
-
     public int ProfileId;
-    public int SlotCount = 8;
-    public List<Slot?> Slots = new();
+
+    public AbilitySet AbilitySet = new();
 
     public AbilityPacketSetDefinition() : base(OpCode)
     {
@@ -67,25 +23,21 @@ public class AbilityPacketSetDefinition : BaseAbilityPacket, ISerializablePacket
     /// <summary>An all-empty toolbar (8 Type-0 slots).</summary>
     public static AbilityPacketSetDefinition CreateEmpty(int profileId)
     {
-        return new AbilityPacketSetDefinition { ProfileId = profileId, SlotCount = 8 };
+        return new AbilityPacketSetDefinition
+        {
+            ProfileId = profileId
+        };
     }
 
     public byte[] Serialize()
     {
         using var writer = new PacketWriter();
 
-        base.Write(writer);
+        Write(writer);
 
         writer.Write(ProfileId);
-        writer.Write(SlotCount);
 
-        for (var i = 0; i < SlotCount; i++)
-        {
-            if (i < Slots.Count && Slots[i] is { } slot)
-                slot.Serialize(writer);
-            else
-                writer.Write(0); // empty slot (Type = 0)
-        }
+        AbilitySet.Serialize(writer);
 
         return writer.Buffer;
     }

--- a/src/Sanctuary.Packet/BaseAbilityPacket/AbilityPacketStartCasting.cs
+++ b/src/Sanctuary.Packet/BaseAbilityPacket/AbilityPacketStartCasting.cs
@@ -1,0 +1,40 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op36 sub3 (S2C) — begins an ability cast on a character: plays the animation and composite effect,
+// and locks the pressed action-bar slot for ActionTime seconds (with an optional progress bar).
+// The proven way to play a cast/attack animation on the player.
+public class AbilityPacketStartCasting : BaseAbilityPacket, ISerializablePacket
+{
+    public new const short OpCode = 3;
+
+    public ulong Unknown;            // caster guid
+    public ulong Unknown2;           // target guid
+    public int CompositeEffectId;    // FX on the caster during the cast
+    public int Animation = -1;       // animation group id (-1 = none)
+    public int AbilityId;
+    public float ActionTime;         // cast duration, seconds — the client's slot-lock window
+    public bool HasActionProgress;   // true = render a progress (cast) bar
+
+    public AbilityPacketStartCasting() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        base.Write(writer);
+
+        writer.Write(Unknown);
+        writer.Write(Unknown2);
+        writer.Write(CompositeEffectId);
+        writer.Write(Animation);
+        writer.Write(AbilityId);
+        writer.Write(ActionTime);
+        writer.Write(HasActionProgress);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseCombatPacket.cs
+++ b/src/Sanctuary.Packet/BaseCombatPacket.cs
@@ -1,0 +1,21 @@
+﻿using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+public class BaseCombatPacket
+{
+    public const short OpCode = 32;
+
+    private short SubOpCode;
+
+    public BaseCombatPacket(short subOpCode)
+    {
+        SubOpCode = subOpCode;
+    }
+
+    public virtual void Write(PacketWriter writer)
+    {
+        writer.Write(OpCode);
+        writer.Write(SubOpCode);
+    }
+}

--- a/src/Sanctuary.Packet/BaseCombatPacket/CombatPacketAttackProcessed.cs
+++ b/src/Sanctuary.Packet/BaseCombatPacket/CombatPacketAttackProcessed.cs
@@ -9,10 +9,9 @@ namespace Sanctuary.Packet;
 //   TARGET: floating damage number (-Damage), health bar (CurrentHealth/MaxHealth), recoil, hit FX.
 // Swapping attacker/target makes the victim swing and go on cooldown while the attacker takes the
 // damage.
-public class CombatPacketAttackProcessed : ISerializablePacket
+public class CombatPacketAttackProcessed : BaseCombatPacket, ISerializablePacket
 {
-    public const short OpCode = 32;
-    public const short SubOpCode = 7;
+    public new const short OpCode = 7;
 
     /// <summary>Who swings.</summary>
     public ulong AttackerGuid;
@@ -37,12 +36,15 @@ public class CombatPacketAttackProcessed : ISerializablePacket
     /// <summary>Target's CURRENT HP after this hit (bar position).</summary>
     public int CurrentHealth;
 
+    public CombatPacketAttackProcessed() : base(OpCode)
+    {
+    }
+
     public byte[] Serialize()
     {
         using var writer = new PacketWriter();
 
-        writer.Write(OpCode);
-        writer.Write(SubOpCode);
+        Write(writer);
 
         writer.Write(AttackerGuid);
         writer.Write(AttackerGuid); // duplicated on the wire

--- a/src/Sanctuary.Packet/BaseCombatPacket/CombatPacketAttackProcessed.cs
+++ b/src/Sanctuary.Packet/BaseCombatPacket/CombatPacketAttackProcessed.cs
@@ -1,0 +1,63 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op32 sub7 "AttackProcessed" — per-hit combat feedback.
+//   ATTACKER (written twice on the wire; the client stores both copies into one field): plays the
+//   attack-contact event — and if it's the LOCAL PLAYER, resets the action-bar melee cooldown timer,
+//   so prefer PlayerUpdatePacketHitPointModification for the player's own hits.
+//   TARGET: floating damage number (-Damage), health bar (CurrentHealth/MaxHealth), recoil, hit FX.
+// Swapping attacker/target makes the victim swing and go on cooldown while the attacker takes the
+// damage.
+public class CombatPacketAttackProcessed : ISerializablePacket
+{
+    public const short OpCode = 32;
+    public const short SubOpCode = 7;
+
+    /// <summary>Who swings.</summary>
+    public ulong AttackerGuid;
+
+    /// <summary>Who takes the number / bar / recoil / hit FX.</summary>
+    public ulong TargetGuid;
+
+    /// <summary>Damage dealt — rendered as a floating -Damage.</summary>
+    public int Damage;
+
+    /// <summary>Target's max HP (health-bar denominator).</summary>
+    public int MaxHealth;
+
+    /// <summary>Hit composite effect id played on the target.</summary>
+    public int CompositeEffectId;
+
+    public bool Bool1;
+    public bool Bool2;
+
+    public int Int4;
+
+    /// <summary>Target's CURRENT HP after this hit (bar position).</summary>
+    public int CurrentHealth;
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        writer.Write(OpCode);
+        writer.Write(SubOpCode);
+
+        writer.Write(AttackerGuid);
+        writer.Write(AttackerGuid); // duplicated on the wire
+        writer.Write(TargetGuid);
+
+        writer.Write(Damage);
+        writer.Write(MaxHealth);
+        writer.Write(CompositeEffectId);
+
+        writer.Write(Bool1);
+        writer.Write(Bool2);
+
+        writer.Write(Int4);
+        writer.Write(CurrentHealth);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseCombatPacket/CombatPacketEnableBossDisplay.cs
+++ b/src/Sanctuary.Packet/BaseCombatPacket/CombatPacketEnableBossDisplay.cs
@@ -1,0 +1,27 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+// op32 sub9 "EnableBossDisplay" — [ulong Guid][bool Enable]. Enable=true registers the actor as a
+// BOSS client-side: the overhead boss health display and boss name treatment. False removes it.
+public class CombatPacketEnableBossDisplay : ISerializablePacket
+{
+    public const short OpCode = 32;
+    public const short SubOpCode = 9;
+
+    public ulong Guid;
+    public bool Enable = true;
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        writer.Write(OpCode);
+        writer.Write(SubOpCode);
+
+        writer.Write(Guid);
+        writer.Write(Enable);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseCombatPacket/CombatPacketEnableBossDisplay.cs
+++ b/src/Sanctuary.Packet/BaseCombatPacket/CombatPacketEnableBossDisplay.cs
@@ -4,20 +4,22 @@ namespace Sanctuary.Packet;
 
 // op32 sub9 "EnableBossDisplay" — [ulong Guid][bool Enable]. Enable=true registers the actor as a
 // BOSS client-side: the overhead boss health display and boss name treatment. False removes it.
-public class CombatPacketEnableBossDisplay : ISerializablePacket
+public class CombatPacketEnableBossDisplay : BaseCombatPacket, ISerializablePacket
 {
-    public const short OpCode = 32;
-    public const short SubOpCode = 9;
+    public new const short OpCode = 9;
 
     public ulong Guid;
     public bool Enable = true;
+
+    public CombatPacketEnableBossDisplay() : base(OpCode)
+    {
+    }
 
     public byte[] Serialize()
     {
         using var writer = new PacketWriter();
 
-        writer.Write(OpCode);
-        writer.Write(SubOpCode);
+        Write(writer);
 
         writer.Write(Guid);
         writer.Write(Enable);


### PR DESCRIPTION
The ability and combat feedback packets, reverse-engineered from the original client:

| Packet | Op/Sub | What it's for |
|---|---|---|
| AbilityPacketSetDefinition | 36/5 | A profile's on-screen ability toolbar (positional slots, keys 1-4) |
| AbilityPacketStartCasting | 36/3 | Begin a cast: animation, FX, slot lock, optional cast bar |
| CombatPacketAttackProcessed | 32/7 | Per-hit feedback: damage number, health bar, recoil, hit FX |
| CombatPacketEnableBossDisplay | 32/9 | Overhead boss health display on an actor |

Pure additions, nothing sends these yet — the ability handler and combat systems come in follow-up PRs. Part 4, after #74/#75/#76.