### PR TITLE
fix: allow reuse of empty guild names

### DIFF
--- a/src/Sanctuary.Gateway/Handlers/BaseGuildPacket/GuildCreatePacketHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseGuildPacket/GuildCreatePacketHandler.cs
@@ -60,7 +60,16 @@ public static class GuildCreatePacketHandler
         using var dbContext = _dbContextFactory.CreateDbContext();
 
         var normalizedGuildName = guildName.ToLower();
-        var nameTaken = dbContext.Guilds.Any(x => x.Name.ToLower() == normalizedGuildName);
+        var sameNameGuilds = dbContext.Guilds
+            .Where(x => x.Name.ToLower() == normalizedGuildName);
+
+        // Older servers could leave the guild row behind after its last member quit.
+        // Delete that empty row before checking the unique name so it can be reused.
+        sameNameGuilds
+            .Where(x => !x.Members.Any())
+            .ExecuteDelete();
+
+        var nameTaken = sameNameGuilds.Any();
 
         if (nameTaken)
         {


### PR DESCRIPTION
the title is explanatory 