### PR TITLE
Fix GUID spoof on move/jump, rename guard, and tell echo on ignore

### DIFF
--- a/src/Sanctuary.Gateway/Handlers/BaseNameChangePacket/ChangeNameRequestPacketHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseNameChangePacket/ChangeNameRequestPacketHandler.cs
@@ -45,6 +45,7 @@ public static class ChangeNameRequestPacketHandler
         if (connection.Player.Guid != packet.Guid)
         {
             _logger.LogError("Invalid player guid. {guid}", packet.Guid);
+            return true;
         }
 
         var nameChangeResponsePacket = new NameChangeResponsePacket();

--- a/src/Sanctuary.Gateway/Handlers/PacketChat/PacketChatHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketChat/PacketChatHandler.cs
@@ -97,8 +97,10 @@ public static class PacketChatHandler
                             packet.Message
                         );
 
-                        if (!toPlayer.Ignores.Any(x => x.Guid == connection.Player.Guid))
-                            toPlayer.SendTunneled(packet);
+                        if (toPlayer.Ignores.Any(x => x.Guid == connection.Player.Guid))
+                            break;
+
+                        toPlayer.SendTunneled(packet);
 
                         var tellEchoPacket = new TellEchoPacket();
 

--- a/src/Sanctuary.Gateway/Handlers/PlayerUpdatePacketJumpHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PlayerUpdatePacketJumpHandler.cs
@@ -29,6 +29,8 @@ public static class PlayerUpdatePacketJumpHandler
 
         // _logger.LogTrace("Received {name} packet. ( {packet} )", nameof(PlayerUpdatePacketJump), packet);
 
+        packet.Guid = connection.Player.Guid;
+
         connection.Player.UpdatePosition(packet.Position, packet.Rotation);
 
         connection.Player.SendTunneledToVisible(packet);

--- a/src/Sanctuary.Gateway/Handlers/PlayerUpdatePacketUpdatePositionHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PlayerUpdatePacketUpdatePositionHandler.cs
@@ -29,6 +29,8 @@ public static class PlayerUpdatePacketUpdatePositionHandler
 
         // _logger.LogTrace("Received {name} packet. ( {packet} )", nameof(PlayerUpdatePacketUpdatePosition), packet);
 
+        packet.Guid = connection.Player.Guid;
+
         connection.Player.UpdatePosition(packet.Position, packet.Rotation);
 
         connection.Player.SendTunneledToVisible(packet);

--- a/src/Sanctuary.Login/Handlers/LoginRequestHandler.cs
+++ b/src/Sanctuary.Login/Handlers/LoginRequestHandler.cs
@@ -81,18 +81,7 @@ public static class LoginRequestHandler
 
             return true;
         }
-#endif
 
-        if (_options.IsLocked && !user.IsAdmin)
-        {
-            loginReply.Status = 2;
-
-            connection.Send(loginReply);
-
-            return true;
-        }
-
-#if !DEBUG
         user.Session = null;
         user.SessionCreated = null;
 #endif
@@ -101,6 +90,15 @@ public static class LoginRequestHandler
 
         if (dbContext.SaveChanges() <= 0)
         {
+            connection.Send(loginReply);
+
+            return true;
+        }
+
+        if (_options.IsLocked && !user.IsAdmin)
+        {
+            loginReply.Status = 2;
+
             connection.Send(loginReply);
 
             return true;

--- a/src/Sanctuary.Login/Handlers/LoginRequestHandler.cs
+++ b/src/Sanctuary.Login/Handlers/LoginRequestHandler.cs
@@ -81,7 +81,18 @@ public static class LoginRequestHandler
 
             return true;
         }
+#endif
 
+        if (_options.IsLocked && !user.IsAdmin)
+        {
+            loginReply.Status = 2;
+
+            connection.Send(loginReply);
+
+            return true;
+        }
+
+#if !DEBUG
         user.Session = null;
         user.SessionCreated = null;
 #endif
@@ -90,15 +101,6 @@ public static class LoginRequestHandler
 
         if (dbContext.SaveChanges() <= 0)
         {
-            connection.Send(loginReply);
-
-            return true;
-        }
-
-        if (_options.IsLocked && !user.IsAdmin)
-        {
-            loginReply.Status = 2;
-
             connection.Send(loginReply);
 
             return true;


### PR DESCRIPTION
Movement/jump now always broadcast the real player GUID, rename rejects GUID mismatches, and ignored tells no longer show an echo to the sender.