### PR TITLE
Keep pending friend invites until DB accept succeeds and block ignoring friends via interaction

### DIFF
--- a/src/Sanctuary.Game/Entities/Player.cs
+++ b/src/Sanctuary.Game/Entities/Player.cs
@@ -395,7 +395,7 @@ public sealed class Player : ClientPcData, IEntity
         {
             commandPacketInteractionList.List.Interactions.Add(StopIgnoringInteraction.Data);
         }
-        else
+        else if (!Friends.Any(x => x.Guid == player.Guid))
         {
             commandPacketInteractionList.List.Interactions.Add(IgnoreInteraction.Data);
         }

--- a/src/Sanctuary.Game/Interactions/IgnoreInteraction.cs
+++ b/src/Sanctuary.Game/Interactions/IgnoreInteraction.cs
@@ -37,6 +37,9 @@ public class IgnoreInteraction : IInteraction
         if (player.Ignores.Any(x => x.Guid == otherPlayer.Guid))
             return;
 
+        if (player.Friends.Any(x => x.Guid == otherPlayer.Guid))
+            return;
+
         using var dbContext = _dbContextFactory.CreateDbContext();
 
         var dbCharacter = dbContext.Characters.FirstOrDefault(x => x.Id == GuidHelper.GetPlayerId(player.Guid));

--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketConfirmFriendResponseHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketConfirmFriendResponseHandler.cs
@@ -42,7 +42,7 @@ public static class CommandPacketConfirmFriendResponseHandler
 
         _logger.LogTrace("Received {name} packet. ( {packet} )", nameof(CommandPacketConfirmFriendResponse), packet);
 
-        if (!connection.Player.IncomingFriendRequests.TryRemove(packet.Guid))
+        if (!connection.Player.IncomingFriendRequests.Contains(packet.Guid))
             return true;
 
         if (!_zoneManager.TryGetPlayer(packet.Guid, out var player))
@@ -54,25 +54,35 @@ public static class CommandPacketConfirmFriendResponseHandler
         {
             case 0:
                 if (connection.Player.Friends.Any(x => x.Guid == player.Guid))
+                {
+                    connection.Player.IncomingFriendRequests.TryRemove(packet.Guid);
                     return true;
+                }
 
                 if (!OnAccept(player, connection.Player))
                     return true;
+
+                connection.Player.IncomingFriendRequests.TryRemove(packet.Guid);
 
                 friendMessagePacket.Type = FriendMessageType.FriendAddRequestAccepted;
                 break;
 
             case 1:
+                connection.Player.IncomingFriendRequests.TryRemove(packet.Guid);
                 friendMessagePacket.Type = FriendMessageType.FriendAddRequestDeclined;
                 break;
 
             case 2:
+                connection.Player.IncomingFriendRequests.TryRemove(packet.Guid);
                 friendMessagePacket.Type = FriendMessageType.FriendAddRequestTimedOut;
                 break;
 
             default:
                 break;
         }
+
+        if (friendMessagePacket.Type == default)
+            return true;
 
         friendMessagePacket.Guid = connection.Player.Guid;
         friendMessagePacket.Name = connection.Player.Name;

--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketConfirmFriendResponseHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketConfirmFriendResponseHandler.cs
@@ -62,27 +62,22 @@ public static class CommandPacketConfirmFriendResponseHandler
                 if (!OnAccept(player, connection.Player))
                     return true;
 
-                connection.Player.IncomingFriendRequests.TryRemove(packet.Guid);
-
                 friendMessagePacket.Type = FriendMessageType.FriendAddRequestAccepted;
                 break;
 
             case 1:
-                connection.Player.IncomingFriendRequests.TryRemove(packet.Guid);
                 friendMessagePacket.Type = FriendMessageType.FriendAddRequestDeclined;
                 break;
 
             case 2:
-                connection.Player.IncomingFriendRequests.TryRemove(packet.Guid);
                 friendMessagePacket.Type = FriendMessageType.FriendAddRequestTimedOut;
                 break;
 
             default:
-                break;
+                return true;
         }
 
-        if (friendMessagePacket.Type == default)
-            return true;
+        connection.Player.IncomingFriendRequests.TryRemove(packet.Guid);
 
         friendMessagePacket.Guid = connection.Player.Guid;
         friendMessagePacket.Name = connection.Player.Name;


### PR DESCRIPTION
Keeps friend invites until accept is saved successfully, and blocks ignoring friends from the interaction menu, which was missing