### PR TITLE
Fix DB init failure + adjust DB tests to catch similar failures

### DIFF
--- a/src/Sanctuary.Database.MySql/ServiceCollectionExtensions.cs
+++ b/src/Sanctuary.Database.MySql/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Sanctuary.Database.MySql;
@@ -11,8 +12,14 @@ public static class ServiceCollectionExtensions
         if (databaseOptions.Provider != DatabaseProvider.MySql)
             throw new InvalidOperationException($"Expected database provider '{DatabaseProvider.MySql}' but found '{databaseOptions.Provider}'.");
 
-        services.AddDbContextFactory<DatabaseContext, MySqlDatabaseFactory>(builder =>
-            MySqlDatabaseFactory.CreateInstance(builder, databaseOptions), ServiceLifetime.Transient);
+        services.AddSingleton(_ =>
+        {
+            var builder = new DbContextOptionsBuilder<DatabaseContext>();
+            MySqlDatabaseFactory.CreateInstance(builder, databaseOptions);
+            return (DbContextOptions<DatabaseContext>)builder.Options;
+        });
+
+        services.AddSingleton<IDbContextFactory<DatabaseContext>, MySqlDatabaseFactory>();
 
         return services;
     }

--- a/src/Sanctuary.Database.Sqlite/ServiceCollectionExtensions.cs
+++ b/src/Sanctuary.Database.Sqlite/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Sanctuary.Database.Sqlite;
@@ -11,8 +12,14 @@ public static class ServiceCollectionExtensions
         if (databaseOptions.Provider != DatabaseProvider.Sqlite)
             throw new InvalidOperationException($"Expected database provider '{DatabaseProvider.Sqlite}' but found '{databaseOptions.Provider}'.");
 
-        services.AddDbContextFactory<DatabaseContext, SqliteDatabaseFactory>(builder =>
-            SqliteDatabaseFactory.CreateInstance(builder, databaseOptions), ServiceLifetime.Transient);
+        services.AddSingleton(_ =>
+        {
+            var builder = new DbContextOptionsBuilder<DatabaseContext>();
+            SqliteDatabaseFactory.CreateInstance(builder, databaseOptions);
+            return (DbContextOptions<DatabaseContext>)builder.Options;
+        });
+
+        services.AddSingleton<IDbContextFactory<DatabaseContext>, SqliteDatabaseFactory>();
 
         return services;
     }

--- a/src/Sanctuary.Database.Tests/DatabaseTestBase.cs
+++ b/src/Sanctuary.Database.Tests/DatabaseTestBase.cs
@@ -1,0 +1,48 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Sanctuary.Core.Extensions;
+
+namespace Sanctuary.Database.Tests;
+
+public abstract class DatabaseTestBase
+{
+    private ServiceProvider _serviceProvider = null!;
+
+    protected abstract void Configure(IConfigurationBuilder configurationBuilder);
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var configurationBuilder = new ConfigurationBuilder();
+
+        Configure(configurationBuilder);
+
+        var config = configurationBuilder.Build();
+
+        var services = new ServiceCollection();
+
+        services.AddDatabase(config);
+
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _serviceProvider.Dispose();
+    }
+
+    protected async Task<DatabaseContext> CreateDbContextAsync(CancellationToken cancellationToken)
+    {
+        var dbContextFactory = _serviceProvider.GetRequiredService<IDbContextFactory<DatabaseContext>>();
+
+        return await dbContextFactory.CreateDbContextAsync(cancellationToken);
+    }
+}
+

--- a/src/Sanctuary.Database.Tests/MySqlTest.cs
+++ b/src/Sanctuary.Database.Tests/MySqlTest.cs
@@ -1,45 +1,34 @@
-﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
-using Sanctuary.Database.MySql;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Sanctuary.Database.Tests;
 
 [TestClass]
-public class MySqlTest
+public class MySqlTest : DatabaseTestBase
 {
-    private DatabaseContext _context = null!;
+    public TestContext TestContext { get; set; }
 
-    [TestInitialize]
-    public void Setup()
+    protected override void Configure(IConfigurationBuilder configurationBuilder)
     {
-        var databaseOptions = new DatabaseOptions
+        configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            Provider = DatabaseProvider.MySql,
-            ConnectionString = "server=127.0.0.1;port=3306;uid=user;pwd=password;database=sanctuary_test",
-            VersionString = "11.6.0-MariaDB"
-        };
-
-        var builder = new DbContextOptionsBuilder<MySqlDatabaseContext>();
-
-        MySqlDatabaseFactory.CreateInstance(builder, databaseOptions);
-
-        _context = new MySqlDatabaseContext(builder.Options);
-    }
-
-    [TestCleanup]
-    public void Cleanup()
-    {
-        Assert.IsTrue(_context.Database.EnsureDeleted());
-
-        _context.Dispose();
+            ["Database:Provider"] = "MySql",
+            ["Database:ConnectionString"] = "server=127.0.0.1;port=3306;uid=user;pwd=password;database=sanctuary_test",
+            ["Database:VersionString"] = "11.6.0-MariaDB"
+        });
     }
 
     [TestMethod]
-    public void IsValid()
+    public async Task IsValidAsync()
     {
-        _context.Database.Migrate();
+        await using var dbContext = await CreateDbContextAsync(TestContext.CancellationToken);
 
-        Assert.IsTrue(_context.Database.CanConnect());
+        await dbContext.Database.MigrateAsync(TestContext.CancellationToken);
+
+        Assert.IsTrue(await dbContext.Database.CanConnectAsync(TestContext.CancellationToken));
     }
 }

--- a/src/Sanctuary.Database.Tests/Sanctuary.Database.Tests.csproj
+++ b/src/Sanctuary.Database.Tests/Sanctuary.Database.Tests.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Sanctuary.Core\Sanctuary.Core.csproj" />
     <ProjectReference Include="..\Sanctuary.Database\Sanctuary.Database.csproj" />
     <ProjectReference Include="..\Sanctuary.Database.MySql\Sanctuary.Database.MySql.csproj" />
     <ProjectReference Include="..\Sanctuary.Database.Sqlite\Sanctuary.Database.Sqlite.csproj" />

--- a/src/Sanctuary.Database.Tests/SqliteTest.cs
+++ b/src/Sanctuary.Database.Tests/SqliteTest.cs
@@ -1,45 +1,33 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-using Sanctuary.Database.Sqlite;
-
 
 namespace Sanctuary.Database.Tests;
 
 [TestClass]
-public class SqliteTest
+public class SqliteTest : DatabaseTestBase
 {
-    private DatabaseContext _context = null!;
+    public TestContext TestContext { get; set; }
 
-    [TestInitialize]
-    public void Setup()
+    protected override void Configure(IConfigurationBuilder configurationBuilder)
     {
-        var databaseOptions = new DatabaseOptions
+        configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            Provider = DatabaseProvider.Sqlite,
-            ConnectionString = "Data Source=:memory:"
-        };
-
-        var builder = new DbContextOptionsBuilder<SqliteDatabaseContext>();
-
-        SqliteDatabaseFactory.CreateInstance(builder, databaseOptions);
-
-        _context = new SqliteDatabaseContext(builder.Options);
-    }
-
-    [TestCleanup]
-    public void Cleanup()
-    {
-        Assert.IsTrue(_context.Database.EnsureDeleted());
-
-        _context.Dispose();
+            ["Database:Provider"] = "Sqlite",
+            ["Database:ConnectionString"] = "Data Source=:memory:"
+        });
     }
 
     [TestMethod]
-    public void IsValid()
+    public async Task IsValidAsync()
     {
-        _context.Database.Migrate();
+        await using var dbContext = await CreateDbContextAsync(TestContext.CancellationToken);
 
-        Assert.IsTrue(_context.Database.CanConnect());
+        await dbContext.Database.MigrateAsync(TestContext.CancellationToken);
+
+        Assert.IsTrue(await dbContext.Database.CanConnectAsync(TestContext.CancellationToken));
     }
 }


### PR DESCRIPTION
- DB init was failing due to `DatabaseContext` being abstract. Tests didn't catch it because they initialize the DB differently. Change the tests so that they initialize in the same way as the server so they catch init failure. (thanks @EDITzDev)
- Use a singleton in each DB provider instead of DbContextFactory, which fixes the failure.
  - This allows for `DatabaseContext` to continue being an abstract class.
  - This change makes the *factory* the singleton; DB contexts are still created fresh, so there's no risk of stale EF caches.