### PR TITLE
Docker fixes + compose improvements

### DIFF
--- a/src/Docker/Sanctuary.Gateway.dockerfile
+++ b/src/Docker/Sanctuary.Gateway.dockerfile
@@ -8,10 +8,10 @@ WORKDIR /src
 COPY . /src
 RUN dotnet build "Sanctuary.Gateway/Sanctuary.Gateway.csproj" -c $BUILD_CONFIGURATION
 RUN dotnet build "Sanctuary.Database.MySql/Sanctuary.Database.MySql.csproj" -c $BUILD_CONFIGURATION
-RUN dotnet build "Sanctuary.Database.SqLite/Sanctuary.Database.Sqlite.csproj" -c $BUILD_CONFIGURATION
+RUN dotnet build "Sanctuary.Database.Sqlite/Sanctuary.Database.Sqlite.csproj" -c $BUILD_CONFIGURATION
 
 FROM base AS final
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /app
-COPY --from=build /src/**/bin/$BUILD_CONFIGURATION .
+COPY --from=build /src/**/bin/$BUILD_CONFIGURATION/net9.0 .
 ENTRYPOINT ["dotnet", "Sanctuary.Gateway.dll"]

--- a/src/Docker/Sanctuary.Login.dockerfile
+++ b/src/Docker/Sanctuary.Login.dockerfile
@@ -9,10 +9,10 @@ WORKDIR /src
 COPY . /src
 RUN dotnet build "Sanctuary.Login/Sanctuary.Login.csproj" -c $BUILD_CONFIGURATION
 RUN dotnet build "Sanctuary.Database.MySql/Sanctuary.Database.MySql.csproj" -c $BUILD_CONFIGURATION
-RUN dotnet build "Sanctuary.Database.SqLite/Sanctuary.Database.Sqlite.csproj" -c $BUILD_CONFIGURATION
+RUN dotnet build "Sanctuary.Database.Sqlite/Sanctuary.Database.Sqlite.csproj" -c $BUILD_CONFIGURATION
 
 FROM base AS final
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /app
-COPY --from=build /src/**/bin/$BUILD_CONFIGURATION .
+COPY --from=build /src/**/bin/$BUILD_CONFIGURATION/net9.0 .
 ENTRYPOINT ["dotnet", "Sanctuary.Login.dll"]

--- a/src/Docker/Sanctuary.WebAPI.dockerfile
+++ b/src/Docker/Sanctuary.WebAPI.dockerfile
@@ -8,10 +8,10 @@ WORKDIR /src
 COPY . /src
 RUN dotnet build "Sanctuary.WebAPI/Sanctuary.WebAPI.csproj" -c $BUILD_CONFIGURATION
 RUN dotnet build "Sanctuary.Database.MySql/Sanctuary.Database.MySql.csproj" -c $BUILD_CONFIGURATION
-RUN dotnet build "Sanctuary.Database.SqLite/Sanctuary.Database.Sqlite.csproj" -c $BUILD_CONFIGURATION
+RUN dotnet build "Sanctuary.Database.Sqlite/Sanctuary.Database.Sqlite.csproj" -c $BUILD_CONFIGURATION
 
 FROM base AS final
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /app
-COPY --from=build /src/**/bin/$BUILD_CONFIGURATION .
+COPY --from=build /src/**/bin/$BUILD_CONFIGURATION/net9.0 .
 ENTRYPOINT ["dotnet", "Sanctuary.WebAPI.dll"]

--- a/src/Docker/docker-compose.yml
+++ b/src/Docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "3306:3306"
     volumes:
-      - ../../database:/var/lib/mysql
+      - db:/var/lib/mysql
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 10s
@@ -71,3 +71,6 @@ services:
     depends_on:
       sanctuary.mysql:
         condition: service_healthy
+
+volumes:
+  db:

--- a/src/Docker/docker-compose.yml
+++ b/src/Docker/docker-compose.yml
@@ -1,4 +1,46 @@
 services:
+  sanctuary.mysql:
+    image: mariadb:10.5
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-sanctuary}
+      MYSQL_USER: ${MYSQL_USER:-sanctuary}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-sanctuary}
+    ports:
+      - "3306:3306"
+    volumes:
+      - ../../database:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  sanctuary.webapi:
+    image: ${DOCKER_REGISTRY-}sanctuary-webapi
+    build:
+      context: ../
+      dockerfile: Docker/Sanctuary.WebAPI.dockerfile
+    restart: unless-stopped
+    ports:
+      - "20040:20040"
+    volumes: &common-volumes
+      - ../../logs:/app/Logs
+      - ../../src/Resources:/app/Resources
+      - ../../src/Scripts:/app/Scripts
+    environment: &common-env
+      - Database__Provider=0 # MySql (MariaDB uses the same provider)
+      - Database__VersionString=10.5.29-mariadb
+      - Database__ConnectionString=Server=sanctuary.mysql;Port=3306;Database=${MYSQL_DATABASE:-sanctuary};User=${MYSQL_USER:-sanctuary};Password=${MYSQL_PASSWORD:-sanctuary};
+      - Server__LoginGatewayAddress=sanctuary.login:20041
+      - Server__ServerAddress=localhost:20260 # replace 'localhost' with your public IP or domain name
+      - Urls=http://0.0.0.0:20040
+    depends_on:
+      sanctuary.mysql:
+        condition: service_healthy
+
   sanctuary.gateway:
     image: ${DOCKER_REGISTRY-}sanctuary-gateway
     build:
@@ -7,16 +49,11 @@ services:
     restart: unless-stopped
     ports:
       - "20260:20260/udp"
-    volumes: &common-volumes
-      - logs:/app/Logs
-      - ./Resources:/app/Resources
-      - ./.local_data:/data
-    environment: &common-env
-      - Database__Provider=1 # SQLite
-      - Database__VersionString=3.0.0-sqlite
-      - Database__ConnectionString=Data Source=/data/sanctuary.db;
-      - Server__LoginGatewayAddress=sanctuary.login:20041
+    volumes: *common-volumes
+    environment: *common-env
     depends_on:
+      sanctuary.mysql:
+        condition: service_healthy
       sanctuary.login:
         condition: service_started
 
@@ -31,6 +68,6 @@ services:
       - "20042:20042/udp"
     volumes: *common-volumes
     environment: *common-env
-
-volumes:
-  logs:
+    depends_on:
+      sanctuary.mysql:
+        condition: service_healthy


### PR DESCRIPTION
- Fix Docker image builds
  - SqLite -> Sqlite rename broke build in case-sensitive contexts (like Linux)
  - Since switching to .slnx, builds now go into a `net9.0` subfolder
- Various improvements to `docker-compose.yml` to allow for a zero-config full instance of Sanctuary
  - Add an instance of the WebAPI service so registration and login work out of the box
  - Add a MariaDB instance and use it as the database provider
    - SQLite isn't the appropriate choice for a containerized deployment; it's meant for local debugging. Also, it was broken, because the docker bindings for the database file didn't exist in the first place, so each container created a fresh, isolated copy of the DB that the other containers couldn't see.
    - Use a named volume to back the data. No need for a local binding, since you can access the database through a MariaDB client as normal.
  - Use a local binding for logs so they can easily be inspected on disk

Battle-tested on the public server, as well as my own dev environments.