### PR TITLE
Fix mounted collection node interactions

### DIFF
--- a/src/Sanctuary.Game/Entities/Player.cs
+++ b/src/Sanctuary.Game/Entities/Player.cs
@@ -132,6 +132,36 @@ public sealed class Player : ClientPcData, IEntity
         _connection.Disconnect();
     }
 
+    public void Dismount()
+    {
+        if (Mount is null)
+            return;
+
+        SendTunneledToVisible(new PacketDismountResponse
+        {
+            RiderGuid = Guid,
+            CompositeEffectId = 0
+        }, sendToSelf: true);
+
+        UpdateCharacterStats(
+            CharacterStats.MaxMovementSpeed.Set(8f),
+            CharacterStats.GlideEnabled.Set(0),
+            CharacterStats.JumpHeight.Set(0f));
+
+        SendTunneledToVisible(new PlayerUpdatePacketRemovePlayerGracefully
+        {
+            Guid = Mount.Guid,
+            Animate = false,
+            Delay = 0,
+            EffectDelay = 0,
+            CompositeEffectId = 46,
+            Duration = 1000
+        }, sendToSelf: true);
+
+        Mount.Dispose();
+        Mount = null;
+    }
+
     #endregion
 
     #region Update

--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketInteractRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketInteractRequestHandler.cs
@@ -67,6 +67,8 @@ public static class CommandPacketInteractRequestHandler
         if (!node.TryReserve())
             return true;
 
+        connection.Player.Dismount();
+
         var itemPersisted = false;
         var nodeCompleted = false;
 

--- a/src/Sanctuary.Gateway/Handlers/MountBasePacket/PacketDismountRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/MountBasePacket/PacketDismountRequestHandler.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 using Sanctuary.Packet;
-using Sanctuary.Packet.Common;
 using Sanctuary.Packet.Common.Attributes;
 
 namespace Sanctuary.Gateway.Handlers;
@@ -24,35 +23,7 @@ public static class PacketDismountRequestHandler
     {
         _logger.LogTrace("Received {name} packet.", nameof(PacketDismountRequest));
 
-        if (connection.Player.Mount is null)
-            return true;
-
-        var packetDismountResponse = new PacketDismountResponse
-        {
-            RiderGuid = connection.Player.Guid,
-            CompositeEffectId = 0,
-        };
-
-        connection.Player.SendTunneledToVisible(packetDismountResponse, true);
-
-        connection.Player.UpdateCharacterStats(
-            CharacterStats.MaxMovementSpeed.Set(8f),
-            CharacterStats.GlideEnabled.Set(0),
-            CharacterStats.JumpHeight.Set(0f));
-
-        connection.Player.SendTunneledToVisible(new PlayerUpdatePacketRemovePlayerGracefully
-        {
-            Guid = connection.Player.Mount.Guid,
-            Animate = false,
-            Delay = 0,
-            EffectDelay = 0,
-            CompositeEffectId = 46,
-            Duration = 1000,
-        }, true);
-
-        connection.Player.Mount.Dispose();
-        connection.Player.Mount = null;
-
+        connection.Player.Dismount();
         return true;
     }
 }


### PR DESCRIPTION
## Summary

- I moved the existing dismount sequence into `Player.Dismount()` so client-requested and server-triggered dismounts use the same packet and state cleanup path.
- I dismount a mounted player after they reserve a collection node and before the collection self-refresh is sent.
- This prevents the collection refresh from leaving the client visually mounted while its mount state is out of sync.

## Testing

- `dotnet build src/Sanctuary.Gateway/Sanctuary.Gateway.csproj --no-restore`
- `dotnet test src/Sanctuary.Game.Tests/Sanctuary.Game.Tests.csproj --no-restore` (24 passed)
- Deployed the change to a live test server and collected a mushroom while mounted. The player dismounted correctly, the reward and live collection update still worked, the node despawned, and the player could mount again afterward.