### PR TITLE
Revert Fix mounted collection node interactions

### DIFF
--- a/src/Sanctuary.Game/Entities/Player.cs
+++ b/src/Sanctuary.Game/Entities/Player.cs
@@ -132,36 +132,6 @@ public sealed class Player : ClientPcData, IEntity
         _connection.Disconnect();
     }
 
-    public void Dismount()
-    {
-        if (Mount is null)
-            return;
-
-        SendTunneledToVisible(new PacketDismountResponse
-        {
-            RiderGuid = Guid,
-            CompositeEffectId = 0
-        }, sendToSelf: true);
-
-        UpdateCharacterStats(
-            CharacterStats.MaxMovementSpeed.Set(8f),
-            CharacterStats.GlideEnabled.Set(0),
-            CharacterStats.JumpHeight.Set(0f));
-
-        SendTunneledToVisible(new PlayerUpdatePacketRemovePlayerGracefully
-        {
-            Guid = Mount.Guid,
-            Animate = false,
-            Delay = 0,
-            EffectDelay = 0,
-            CompositeEffectId = 46,
-            Duration = 1000
-        }, sendToSelf: true);
-
-        Mount.Dispose();
-        Mount = null;
-    }
-
     #endregion
 
     #region Update

--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketInteractRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketInteractRequestHandler.cs
@@ -67,8 +67,6 @@ public static class CommandPacketInteractRequestHandler
         if (!node.TryReserve())
             return true;
 
-        connection.Player.Dismount();
-
         var itemPersisted = false;
         var nodeCompleted = false;
 

--- a/src/Sanctuary.Gateway/Handlers/MountBasePacket/PacketDismountRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/MountBasePacket/PacketDismountRequestHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 using Sanctuary.Packet;
+using Sanctuary.Packet.Common;
 using Sanctuary.Packet.Common.Attributes;
 
 namespace Sanctuary.Gateway.Handlers;
@@ -23,7 +24,35 @@ public static class PacketDismountRequestHandler
     {
         _logger.LogTrace("Received {name} packet.", nameof(PacketDismountRequest));
 
-        connection.Player.Dismount();
+        if (connection.Player.Mount is null)
+            return true;
+
+        var packetDismountResponse = new PacketDismountResponse
+        {
+            RiderGuid = connection.Player.Guid,
+            CompositeEffectId = 0,
+        };
+
+        connection.Player.SendTunneledToVisible(packetDismountResponse, true);
+
+        connection.Player.UpdateCharacterStats(
+            CharacterStats.MaxMovementSpeed.Set(8f),
+            CharacterStats.GlideEnabled.Set(0),
+            CharacterStats.JumpHeight.Set(0f));
+
+        connection.Player.SendTunneledToVisible(new PlayerUpdatePacketRemovePlayerGracefully
+        {
+            Guid = connection.Player.Mount.Guid,
+            Animate = false,
+            Delay = 0,
+            EffectDelay = 0,
+            CompositeEffectId = 46,
+            Duration = 1000,
+        }, true);
+
+        connection.Player.Mount.Dispose();
+        connection.Player.Mount = null;
+
         return true;
     }
 }


### PR DESCRIPTION
## Summary

- Reverts #94 while mounted collection interactions are investigated.
- Runtime testing showed that a server-triggered dismount does not reproduce the client-side action-state transition performed by a normal client-initiated dismount.
- Depending on packet ordering, players can remount without receiving a dismount action or remain stuck unable to remount.

The collection interaction should instead use the client update packet dedicated to collection progress, avoiding the full player refresh that caused the original mount desync.

## Testing

- `dotnet build src/Sanctuary.Gateway/Sanctuary.Gateway.csproj` (0 warnings, 0 errors)
- `dotnet test src/Sanctuary.Game.Tests/Sanctuary.Game.Tests.csproj` (24 passed)