### PR TITLE
Use native collection update packets

### DIFF
--- a/src/Resources/Collections.json
+++ b/src/Resources/Collections.json
@@ -1,9 +1,9 @@
 [
   {
-    "Id": 17054,
-    "CategoryId": 10,
+    "Id": 10,
+    "NameId": 17054,
+    "CategoryId": 3,
     "DescriptionId": 17055,
-    "Type": 3,
     "IconId": 2124,
     "IconTintId": 92,
     "HeaderMetadata": 9,

--- a/src/Sanctuary.Game.Tests/CollectionDefinitionTests.cs
+++ b/src/Sanctuary.Game.Tests/CollectionDefinitionTests.cs
@@ -15,6 +15,7 @@ public sealed class CollectionDefinitionTests
         var definition = new CollectionDefinition
         {
             Id = 17054,
+            NameId = 17055,
             CategoryId = 10,
             Entries =
             [
@@ -30,5 +31,34 @@ public sealed class CollectionDefinitionTests
         Assert.IsFalse(clientCollection.Entries[0].Collected);
         Assert.IsTrue(clientCollection.Entries[1].Collected);
         Assert.AreEqual(123ul, clientCollection.PlayerGuid);
+    }
+
+    [TestMethod]
+    public void CreateClientCollectionEntry_UsesCollectionMetadata()
+    {
+        var definition = new CollectionDefinition
+        {
+            Id = 17054,
+            NameId = 17055,
+            CategoryId = 10
+        };
+        var entry = new CollectionEntryDefinition
+        {
+            Id = 41,
+            NameId = 17056,
+            IconId = 2124,
+            IconTintId = 99
+        };
+
+        var clientEntry = definition.CreateClientCollectionEntry(entry, 2, true);
+
+        Assert.AreEqual(entry.Id, clientEntry.Id);
+        Assert.AreEqual(entry.Id, clientEntry.DefinitionId);
+        Assert.AreEqual(3, clientEntry.Index);
+        Assert.AreEqual(definition.Id, clientEntry.CollectionId);
+        Assert.AreEqual(entry.NameId, clientEntry.NameId);
+        Assert.AreEqual(entry.IconId, clientEntry.IconId);
+        Assert.AreEqual(entry.IconTintId, clientEntry.IconTintId);
+        Assert.IsTrue(clientEntry.Collected);
     }
 }

--- a/src/Sanctuary.Game/Resources/CollectionDefinitionCollection.cs
+++ b/src/Sanctuary.Game/Resources/CollectionDefinitionCollection.cs
@@ -80,7 +80,8 @@ public sealed class CollectionDefinitionCollection : ObservableConcurrentDiction
 
         foreach (var definition in definitions)
         {
-            if (definition.Id <= 0 || definition.CategoryId <= 0 || definition.Entries.Count == 0)
+            if (definition.Id <= 0 || definition.NameId <= 0 || definition.CategoryId <= 0 ||
+                definition.Entries.Count == 0)
             {
                 _logger.LogError("Collection {id} has invalid required data in \"{file}\".", definition.Id, filePath);
                 return false;

--- a/src/Sanctuary.Game/Resources/Definitions/CollectionDefinition.cs
+++ b/src/Sanctuary.Game/Resources/Definitions/CollectionDefinition.cs
@@ -8,9 +8,9 @@ namespace Sanctuary.Game.Resources.Definitions;
 public sealed class CollectionDefinition
 {
     public int Id { get; set; }
+    public int NameId { get; set; }
     public int CategoryId { get; set; }
     public int DescriptionId { get; set; }
-    public int Type { get; set; }
     public int IconId { get; set; }
     public int IconTintId { get; set; }
     public int HeaderMetadata { get; set; }
@@ -26,10 +26,10 @@ public sealed class CollectionDefinition
     {
         var collection = new ClientCollection
         {
-            CategoryId = CategoryId,
             Id = Id,
+            NameId = NameId,
             DescriptionId = DescriptionId,
-            Type = Type,
+            CategoryId = CategoryId,
             IconId = IconId,
             IconTintId = IconTintId,
             HeaderMetadata = HeaderMetadata,
@@ -39,21 +39,25 @@ public sealed class CollectionDefinition
 
         for (var index = 0; index < Entries.Count; index++)
         {
-            var entry = Entries[index];
-
-            collection.Entries.Add(new ClientCollectionEntry
-            {
-                Id = entry.Id,
-                DefinitionId = entry.Id,
-                Index = index + 1,
-                CategoryId = CategoryId,
-                NameId = entry.NameId,
-                IconId = entry.IconId,
-                IconTintId = entry.IconTintId,
-                Collected = ownedItemDefinitionIds.Contains(entry.ItemDefinitionId)
-            });
+            collection.Entries.Add(CreateClientCollectionEntry(
+                Entries[index], index, ownedItemDefinitionIds.Contains(Entries[index].ItemDefinitionId)));
         }
 
         return collection;
+    }
+
+    public ClientCollectionEntry CreateClientCollectionEntry(CollectionEntryDefinition entry, int index, bool collected)
+    {
+        return new ClientCollectionEntry
+        {
+            Id = entry.Id,
+            DefinitionId = entry.Id,
+            Index = index + 1,
+            CollectionId = Id,
+            NameId = entry.NameId,
+            IconId = entry.IconId,
+            IconTintId = entry.IconTintId,
+            Collected = collected
+        };
     }
 }

--- a/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketInteractRequestHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCommandPacket/CommandPacketInteractRequestHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 
@@ -12,6 +13,7 @@ using Sanctuary.Database;
 using Sanctuary.Database.Entities;
 using Sanctuary.Game;
 using Sanctuary.Game.Entities;
+using Sanctuary.Game.Resources.Definitions;
 using Sanctuary.Packet;
 using Sanctuary.Packet.Common;
 using Sanctuary.Packet.Common.Attributes;
@@ -67,8 +69,6 @@ public static class CommandPacketInteractRequestHandler
         if (!node.TryReserve())
             return true;
 
-        connection.Player.Dismount();
-
         var itemPersisted = false;
         var nodeCompleted = false;
 
@@ -85,6 +85,14 @@ public static class CommandPacketInteractRequestHandler
                 node.Release();
                 return true;
             }
+
+            var ownedItemDefinitionIds = connection.Player.Items
+                .Select(item => item.Definition)
+                .ToHashSet();
+            var collectionMatch = FindCollectionEntry(itemDefinitionId);
+            var collectionWasStarted = collectionMatch is not null &&
+                collectionMatch.Value.Definition.IsStarted(ownedItemDefinitionIds);
+            var collectionEntryWasCollected = ownedItemDefinitionIds.Contains(itemDefinitionId);
 
             var characterId = GuidHelper.GetPlayerId(connection.Player.Guid);
 
@@ -157,13 +165,24 @@ public static class CommandPacketInteractRequestHandler
                 });
             }
 
+            ownedItemDefinitionIds.Add(itemDefinitionId);
+
             node.CompleteCollection();
             nodeCompleted = true;
 
-            // The delta packet is not fully decoded. The authoritative self packet is
-            // capture-validated and refreshes an already-open collection panel.
-            connection.SendSelfToClient();
-            SendCollectionRewardToast(connection, clientItem, itemDefinition, node);
+            if (collectionMatch is not null && !collectionEntryWasCollected)
+            {
+                if (!collectionWasStarted)
+                    SendCollectionStart(connection, collectionMatch.Value.Definition, ownedItemDefinitionIds);
+
+                SendCollectionEntryUpdate(connection, collectionMatch.Value.Definition,
+                    collectionMatch.Value.Entry, collectionMatch.Value.Index);
+            }
+            else
+            {
+                SendCollectionRewardToast(connection, clientItem, itemDefinition, node);
+            }
+
             return true;
         }
         catch (Exception ex)
@@ -177,6 +196,51 @@ public static class CommandPacketInteractRequestHandler
 
             return false;
         }
+    }
+
+    private static CollectionEntryMatch? FindCollectionEntry(int itemDefinitionId)
+    {
+        foreach (var definition in _resourceManager.Collections.Values)
+        {
+            for (var index = 0; index < definition.Entries.Count; index++)
+            {
+                var entry = definition.Entries[index];
+
+                if (entry.ItemDefinitionId == itemDefinitionId)
+                    return new CollectionEntryMatch(definition, entry, index);
+            }
+        }
+
+        return null;
+    }
+
+    private static void SendCollectionStart(GatewayConnection connection, CollectionDefinition definition,
+        IReadOnlySet<int> ownedItemDefinitionIds)
+    {
+        var collection = definition.CreateClientCollection(connection.Player.Guid, ownedItemDefinitionIds);
+
+        using var writer = new PacketWriter();
+        collection.Serialize(writer);
+
+        connection.SendTunneled(new ClientUpdatePacketCollectionStart { Payload = writer.Buffer });
+    }
+
+    private static void SendCollectionEntryUpdate(GatewayConnection connection, CollectionDefinition definition,
+        CollectionEntryDefinition entryDefinition, int index)
+    {
+        var entry = definition.CreateClientCollectionEntry(entryDefinition, index, true);
+
+        connection.SendTunneled(new ClientUpdatePacketCollectionAddEntry
+        {
+            DefinitionId = entry.DefinitionId,
+            IconId = entry.IconId,
+            IconTintId = entry.IconTintId,
+            NameId = entry.NameId,
+            CollectionId = entry.CollectionId,
+            Index = entry.Index,
+            Unknown = entry.Unknown,
+            Collected = entry.Collected
+        });
     }
 
     private static void SendCollectionRewardToast(GatewayConnection connection, ClientItem clientItem,
@@ -203,4 +267,9 @@ public static class CommandPacketInteractRequestHandler
 
         connection.SendTunneled(packet);
     }
+
+    private readonly record struct CollectionEntryMatch(
+        CollectionDefinition Definition,
+        CollectionEntryDefinition Entry,
+        int Index);
 }

--- a/src/Sanctuary.Packet.Common/ClientCollection.cs
+++ b/src/Sanctuary.Packet.Common/ClientCollection.cs
@@ -6,10 +6,10 @@ namespace Sanctuary.Packet.Common;
 
 public sealed class ClientCollection : ISerializableType
 {
-    public int CategoryId;
     public int Id;
+    public int NameId;
     public int DescriptionId;
-    public int Type;
+    public int CategoryId;
     public int IconId;
     public int IconTintId;
 
@@ -50,10 +50,10 @@ public sealed class ClientCollection : ISerializableType
 
     public void Serialize(PacketWriter writer)
     {
-        writer.Write(CategoryId);
         writer.Write(Id);
+        writer.Write(NameId);
         writer.Write(DescriptionId);
-        writer.Write(Type);
+        writer.Write(CategoryId);
         writer.Write(IconId);
         writer.Write(IconTintId);
 

--- a/src/Sanctuary.Packet.Common/ClientCollectionEntry.cs
+++ b/src/Sanctuary.Packet.Common/ClientCollectionEntry.cs
@@ -7,7 +7,7 @@ public sealed class ClientCollectionEntry : ISerializableType
     public int Id;
     public int DefinitionId;
     public int Index;
-    public int CategoryId;
+    public int CollectionId;
     public int NameId;
     public int IconId;
     public int IconTintId;
@@ -19,7 +19,7 @@ public sealed class ClientCollectionEntry : ISerializableType
         writer.Write(Id);
         writer.Write(DefinitionId);
         writer.Write(Index);
-        writer.Write(CategoryId);
+        writer.Write(CollectionId);
         writer.Write(NameId);
         writer.Write(IconId);
         writer.Write(IconTintId);

--- a/src/Sanctuary.Packet/BaseClientUpdatePacket/ClientUpdatePacketCollectionAddEntry.cs
+++ b/src/Sanctuary.Packet/BaseClientUpdatePacket/ClientUpdatePacketCollectionAddEntry.cs
@@ -1,0 +1,38 @@
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+public sealed class ClientUpdatePacketCollectionAddEntry : BaseClientUpdatePacket, ISerializablePacket
+{
+    public new const short OpCode = 10;
+
+    public int DefinitionId;
+    public int IconId;
+    public int IconTintId;
+    public int NameId;
+    public int CollectionId;
+    public int Index;
+    public int Unknown;
+    public bool Collected = true;
+
+    public ClientUpdatePacketCollectionAddEntry() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+        writer.Write(DefinitionId);
+        writer.Write(IconId);
+        writer.Write(IconTintId);
+        writer.Write(NameId);
+        writer.Write(CollectionId);
+        writer.Write(Index);
+        writer.Write(Unknown);
+        writer.Write(Collected);
+
+        return writer.Buffer;
+    }
+}

--- a/src/Sanctuary.Packet/BaseClientUpdatePacket/ClientUpdatePacketCollectionStart.cs
+++ b/src/Sanctuary.Packet/BaseClientUpdatePacket/ClientUpdatePacketCollectionStart.cs
@@ -1,0 +1,26 @@
+using System;
+
+using Sanctuary.Core.IO;
+
+namespace Sanctuary.Packet;
+
+public sealed class ClientUpdatePacketCollectionStart : BaseClientUpdatePacket, ISerializablePacket
+{
+    public new const short OpCode = 8;
+
+    public byte[] Payload = Array.Empty<byte>();
+
+    public ClientUpdatePacketCollectionStart() : base(OpCode)
+    {
+    }
+
+    public byte[] Serialize()
+    {
+        using var writer = new PacketWriter();
+
+        Write(writer);
+        writer.WritePayload(Payload);
+
+        return writer.Buffer;
+    }
+}


### PR DESCRIPTION
## Summary

I replaced the full player refresh used after collecting a node with the
client's native collection update packets.

The full `PacketSendSelfToClient` refresh updated the Collections panel, but it
also disturbed unrelated client state. Most visibly, collecting while mounted
could desync the mount and action UI. PR #94 tried to compensate by dismounting
the player server-side, but runtime testing showed that this does not reproduce
the client-side state transition of a normal dismount. This PR reverts that
workaround and removes the broad refresh that made it necessary.

## What changed

- Added `ClientUpdatePacketCollectionStart` for starting a collection.
- Added `ClientUpdatePacketCollectionAddEntry` for adding live progress.
- Corrected the decoded collection and collection-entry field meanings.
- Replaced the full self refresh and generic reward toast with native
  collection updates.
- Reverted the collection-triggered mount workaround from #94.
- Updated the Briarwood collection definition to use the corrected schema.

The client now creates its original collection started, progress, and completed
notifications from these packets.

## Packet research

I traced the `BaseClientUpdatePacket` collection handlers in the client:

- subtype `8`: collection start
- subtype `10`: collection add entry

The add-entry handler updates the client's collection manager, marks both
collection views dirty, and creates the native collection UI action. This
explains why the previous full player refresh could change the panel without
behaving like an original collection event.

For an unknown collection, the server sends subtype 8 with the serialized
collection state containing the first collected entry. For an already-started
collection, it sends subtype 10 with the newly collected entry.

## Runtime testing

- Started a previously unknown collection and received the native start/update
  notification.
- Added later entries and saw the open Collections panel update live.
- Completed a collection and received the native completion notification.
- Confirmed collection progress persisted after relogging.
- Collected while mounted without forcing a dismount or refreshing the full
  player state.
- Confirmed normal mount controls remained available after collecting.

## Automated validation

- `dotnet build src/Sanctuary.slnx --no-restore`
  - 0 warnings
  - 0 errors
- `Sanctuary.Game.Tests`
  - 24 passed
- `Sanctuary.Scripting.Tests`
  - 2 passed
- `Sanctuary.UdpLibrary.Tests`
  - 1 passed
- The SQLite database test passed. The MySQL integration test was unavailable
  locally because no MySQL service was running.
