### PR TITLE
BUG FIX: Sell items in the shop

### DIFF
--- a/src/Sanctuary.Gateway/Handlers/BaseCoinStorePacket/CoinStoreBuyFromClientRequestPacketHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/BaseCoinStorePacket/CoinStoreBuyFromClientRequestPacketHandler.cs
@@ -58,7 +58,9 @@ public static class CoinStoreBuyFromClientRequestPacketHandler
             return true;
         }
 
-        if (clientItem.Count < packet.Quantity)
+        var sellQuantity = packet.Quantity <= 0 ? clientItem.Count : packet.Quantity;
+
+        if (clientItem.Count < sellQuantity)
         {
             coinStoreTransactionCompletePacket.Result = 4;
 
@@ -98,14 +100,14 @@ public static class CoinStoreBuyFromClientRequestPacketHandler
 
         var dbItem = dbQuery.Item;
 
-        var deleteItem = clientItem.Count == packet.Quantity;
+        var deleteItem = clientItem.Count == sellQuantity;
 
         if (deleteItem)
             dbContext.Items.Remove(dbItem);
         else
-            dbItem.Count -= packet.Quantity;
+            dbItem.Count -= sellQuantity;
 
-        dbQuery.Character.Coins += clientItemDefinition.ResellValue * packet.Quantity;
+        dbQuery.Character.Coins += clientItemDefinition.ResellValue * sellQuantity;
 
         if (dbContext.SaveChanges() <= 0)
         {
@@ -163,7 +165,7 @@ public static class CoinStoreBuyFromClientRequestPacketHandler
         coinStoreTransactionCompletePacket.TransactionRecord.ItemRecord.Definition = clientItem.Definition;
         coinStoreTransactionCompletePacket.TransactionRecord.ItemRecord.Tint = clientItem.Tint;
 
-        coinStoreTransactionCompletePacket.TransactionRecord.Quantity = packet.Quantity;
+        coinStoreTransactionCompletePacket.TransactionRecord.Quantity = sellQuantity;
 
         connection.SendTunneled(coinStoreTransactionCompletePacket);
 


### PR DESCRIPTION
This change updates the sell-to-shop handler so one request can sell an entire inventory stack, not just a fixed quantity.
What it does (CoinStoreBuyFromClientRequestPacketHandler.cs):
Reads the requested packet.Quantity from the client.
If Quantity <= 0, it treats that as “sell all” and sets sellQuantity to clientItem.Count.
Otherwise it uses the requested quantity as before.
It then validates stock, removes the items, credits coins for sellQuantity, updates DB/client counts, and records the transaction with sellQuantity.
In short: it now supports a “sell everything in this stack” path while preserving existing exact-quantity sells.
How it differs from upstream repo (upstream/main):
Upstream only allowed the explicit quantity path:it checked if (clientItem.Count < packet.Quantity)
decremented by packet.Quantity
paid ResellValue * packet.Quantity
recorded transaction Quantity = packet.Quantity