### PR TITLE
Fix: Disconnect idle clients from client metrics

### DIFF
--- a/src/Sanctuary.Gateway/Handlers/PacketClientMetricsHandler.cs
+++ b/src/Sanctuary.Gateway/Handlers/PacketClientMetricsHandler.cs
@@ -29,6 +29,13 @@ public static class PacketClientMetricsHandler
 
         _logger.LogTrace("Received {name} packet. ( {packet} )", nameof(PacketClientMetrics), packet);
 
+        if (packet.Metrics.Idle == 1)
+        {
+            _logger.LogInformation("{connection} disconnected for inactivity. ( Guid: {guid}, IdleTime: {idleTime} )", connection, connection.Player?.Guid, packet.Metrics.IdleTimeout);
+
+            connection.Disconnect();
+        }
+
         return true;
     }
 }


### PR DESCRIPTION

<img width="1910" height="1025" alt="760e4936d8d18f3b076237f3ed8c54a2" src="https://github.com/user-attachments/assets/21dbe6dc-6d23-4d02-b911-e4f9e908de4a" />
It's basically just a repair to the clients lacking AFK Idle timeout