### PR TITLE
First prototype for NPC behaviors.

### DIFF
--- a/src/Sanctuary.Core/Actions/DelegateAction.cs
+++ b/src/Sanctuary.Core/Actions/DelegateAction.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Sanctuary.Core.Actions;
+
+public sealed class DelegateAction : IAction
+{
+    private readonly Action _onStart;
+    private readonly Func<bool> _onTick;
+
+    public DelegateAction(Action? onStart = null, Func<bool>? onTick = null)
+    {
+        _onStart = onStart ?? (() => { });
+        _onTick = onTick ?? (() => true);
+    }
+
+    public void OnStart() => _onStart();
+    public bool OnTick() => _onTick();
+}

--- a/src/Sanctuary.Core/Actions/IAction.cs
+++ b/src/Sanctuary.Core/Actions/IAction.cs
@@ -1,0 +1,9 @@
+namespace Sanctuary.Core.Actions;
+
+public interface IAction
+{
+    void OnStart() { }
+    bool OnTick() => false;
+
+    // TODO: 'OnSecond'?
+}

--- a/src/Sanctuary.Core/Actions/InstantAction.cs
+++ b/src/Sanctuary.Core/Actions/InstantAction.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Sanctuary.Core.Actions;
+
+public sealed class InstantAction : IAction
+{
+    private readonly Action _action;
+
+    public InstantAction(Action action)
+    {
+        _action = action;
+    }
+
+    public void OnStart() => _action();
+    public bool OnTick() => true;
+}

--- a/src/Sanctuary.Core/Actions/ParallelAction.cs
+++ b/src/Sanctuary.Core/Actions/ParallelAction.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace Sanctuary.Core.Actions;
+
+public sealed class ParallelAction : IAction
+{
+    private readonly List<IAction> _actions;
+
+    public ParallelAction(params IAction[] actions)
+    {
+        _actions = new List<IAction>(actions);
+    }
+
+    public void OnStart()
+    {
+        foreach (var action in _actions)
+        {
+            action.OnStart();
+        }
+    }
+
+    public bool OnTick()
+    {
+        _actions.RemoveAll(action => action.OnTick());
+        return _actions.Count == 0;
+    }
+}

--- a/src/Sanctuary.Core/Actions/SequentialAction.cs
+++ b/src/Sanctuary.Core/Actions/SequentialAction.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace Sanctuary.Core.Actions;
+
+public sealed class SequentialAction : IAction
+{
+    private readonly Queue<IAction> _actions;
+    private IAction? _current;
+
+    public SequentialAction(IEnumerable<IAction> actions) => _actions = new Queue<IAction>(actions);
+
+    public void OnStart() => Advance();
+
+    public bool OnTick()
+    {
+        if (_current is null) return true;
+        if (!_current.OnTick()) return false;
+        return Advance();
+    }
+
+    private bool Advance()
+    {
+        if (!_actions.TryDequeue(out _current)) return true;
+        _current.OnStart();
+        return false;
+    }
+}

--- a/src/Sanctuary.Core/Actions/TimeoutAction.cs
+++ b/src/Sanctuary.Core/Actions/TimeoutAction.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Diagnostics;
+
+namespace Sanctuary.Core.Actions;
+
+public sealed class TimeoutAction : IAction
+{
+    private readonly IAction _action;
+    private readonly double _timeoutSeconds;
+    private readonly Stopwatch _stopwatch = new();
+
+    public TimeoutAction(IAction action, double timeoutSeconds)
+    {
+        _action = action;
+        _timeoutSeconds = timeoutSeconds;
+    }
+
+    public void OnStart()
+    {
+        _stopwatch.Restart();
+        _action.OnStart();
+    }
+
+    public bool OnTick()
+    {
+        return _action.OnTick() || _stopwatch.Elapsed.TotalSeconds >= _timeoutSeconds;
+    }
+}

--- a/src/Sanctuary.Core/Actions/WaitAction.cs
+++ b/src/Sanctuary.Core/Actions/WaitAction.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Diagnostics;
+
+namespace Sanctuary.Core.Actions;
+
+public sealed class WaitAction : IAction
+{
+    private readonly double _seconds;
+    private readonly Stopwatch _stopwatch = new();
+
+    public WaitAction(double seconds) => _seconds = seconds;
+
+    public void OnStart() => _stopwatch.Restart();
+    public bool OnTick() => _stopwatch.Elapsed.TotalSeconds >= _seconds;
+}

--- a/src/Sanctuary.Game/Actions/ActionManager.cs
+++ b/src/Sanctuary.Game/Actions/ActionManager.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+using Sanctuary.Core.Actions;
+
+namespace Sanctuary.Game.Actions;
+
+public sealed class ActionManager
+{
+    private readonly Dictionary<string, IAction> _actions = new();
+
+    public void SetAction(string slot, IAction action)
+    {
+        _actions[slot] = action;
+        action.OnStart();
+    }
+
+    public void Cancel(string slot) => _actions.Remove(slot);
+
+    public void Tick()
+    {
+        List<string>? finished = null;
+
+        foreach (var (key, action) in _actions)
+        {
+            if (action.OnTick())
+                (finished ??= new()).Add(key);
+        }
+
+        if (finished is not null)
+            foreach (var key in finished)
+                _actions.Remove(key);
+    }
+}

--- a/src/Sanctuary.Game/Actions/MoveToAction.cs
+++ b/src/Sanctuary.Game/Actions/MoveToAction.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Numerics;
+
+using Sanctuary.Core.Actions;
+using Sanctuary.Game.Entities;
+using Sanctuary.Game.Pathfinding;
+
+namespace Sanctuary.Game.Actions;
+
+public sealed class MoveToAction : IAction
+{
+    private readonly Npc _npc;
+    private readonly Vector3 _goal;
+    private readonly bool _direct;
+    private readonly PathState _path = new();
+
+    public MoveToAction(Npc npc, Vector3 goal, bool direct = false)
+    {
+        _npc = npc;
+        _goal = goal;
+        _direct = direct;
+    }
+
+    public void OnStart()
+    {
+        if (_direct || _npc.Zone.Pathfinder is null)
+        {
+            var waypoints = new Queue<Vector3>();
+            waypoints.Enqueue(_goal);
+            _path.Set(waypoints);
+            return;
+        }
+
+        var currentPosition = new Vector3(_npc.Position.X, _npc.Position.Y, _npc.Position.Z);
+        var recomputedWaypoints = new PathBuilder(_npc.Zone.Pathfinder).TryRecompute(currentPosition, _goal);
+
+        if (recomputedWaypoints is not null)
+            _path.Set(recomputedWaypoints);
+    }
+
+    public bool OnTick()
+    {
+        var currentPosition = new Vector3(_npc.Position.X, _npc.Position.Y, _npc.Position.Z);
+        var result = PathFollower.Advance(_path, currentPosition, _npc.Speed, _npc.WaypointTolerance, _npc.Zone.TickDeltaSeconds);
+
+        if (result.Moved)
+            _npc.UpdatePosition(new Vector4(result.NewPosition, 1f), result.NewRotation!.Value);
+
+        return result.Arrived;
+    }
+}

--- a/src/Sanctuary.Game/Entities/Npc.cs
+++ b/src/Sanctuary.Game/Entities/Npc.cs
@@ -6,8 +6,9 @@ using System.Numerics;
 
 using Microsoft.Extensions.Logging;
 
+using Sanctuary.Core.Actions;
 using Sanctuary.Core.Collections;
-using Sanctuary.Game.Pathfinding;
+using Sanctuary.Game.Actions;
 using Sanctuary.Game.Zones;
 using Sanctuary.Packet;
 using Sanctuary.Packet.Common;
@@ -84,9 +85,7 @@ public class Npc : IScriptableNpc, IEntity
     public float WaypointTolerance { get; set; } = 0f;
     public float Speed { get; set; } = 6.25f;
 
-    private readonly PathState _path = new();
-
-    private PathBuilder? _pathBuilder;
+    private readonly ActionManager _actions = new();
 
     public Npc(IZone zone)
     {
@@ -132,13 +131,7 @@ public class Npc : IScriptableNpc, IEntity
         if (!_scripts.IsEmpty)
             GetOrCreateScriptContext().FireEvent("tick");
 
-        var currentPosition = new Vector3(Position.X, Position.Y, Position.Z);
-        var result = PathFollower.Advance(_path, currentPosition, Speed, WaypointTolerance, Zone.TickDeltaSeconds);
-
-        if (result.Moved)
-        {
-            UpdatePosition(new Vector4(result.NewPosition, 1f), result.NewRotation!.Value);
-        }
+        _actions.Tick();
     }
 
     public void UpdateEverySecond()
@@ -425,11 +418,13 @@ public class Npc : IScriptableNpc, IEntity
             visiblePlayer.Value.SendTunneled(packet);
     }
 
-    public void MoveTo(float x, float y, float z, bool direct)
+    public IAction MoveTo(float x, float y, float z, bool direct)
     {
-        MoveTo(new Vector3(x, y, z), direct);
+        return MoveTo(new Vector3(x, y, z), direct);
     }
-    
+
+    public void SetAction(string slot, IAction action) => _actions.SetAction(slot, action);
+
     #endregion
 
     public virtual void Dispose()
@@ -460,21 +455,8 @@ public class Npc : IScriptableNpc, IEntity
         Zone.TryRemoveNpc(Guid);
     }
 
-    public void MoveTo(Vector3 goalPosition, bool direct = false)
+    public IAction MoveTo(Vector3 goalPosition, bool direct = false)
     {
-        if (direct || Zone.Pathfinder is null)
-        {
-            var waypoints = new Queue<Vector3>();
-            waypoints.Enqueue(goalPosition);
-            _path.Set(waypoints);
-            return;
-        }
-
-        _pathBuilder ??= new PathBuilder(Zone.Pathfinder);
-
-        var currentPosition = new Vector3(Position.X, Position.Y, Position.Z);
-        var newWaypoints = _pathBuilder.TryRecompute(currentPosition, goalPosition);
-        if (newWaypoints is not null)
-            _path.Set(newWaypoints);
+        return new MoveToAction(this, goalPosition, direct);
     }
 }

--- a/src/Sanctuary.Scripting.Tests/MockScriptNpc.cs
+++ b/src/Sanctuary.Scripting.Tests/MockScriptNpc.cs
@@ -2,6 +2,8 @@ using System;
 
 using Microsoft.Extensions.Logging;
 
+using Sanctuary.Core.Actions;
+
 namespace Sanctuary.Scripting.Tests;
 
 internal class MockScriptNpc(IScriptableZone _zone) : IScriptableNpc
@@ -28,7 +30,12 @@ internal class MockScriptNpc(IScriptableZone _zone) : IScriptableNpc
         throw new NotImplementedException();
     }
 
-    public void MoveTo(float x, float y, float z, bool direct)
+    public IAction MoveTo(float x, float y, float z, bool direct)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void SetAction(string slot, IAction action)
     {
         throw new NotImplementedException();
     }

--- a/src/Sanctuary.Scripting/IScriptableNpc.cs
+++ b/src/Sanctuary.Scripting/IScriptableNpc.cs
@@ -1,5 +1,7 @@
 using System.Numerics;
 
+using Sanctuary.Core.Actions;
+
 namespace Sanctuary.Scripting;
 
 public interface IScriptableNpc : IScriptable
@@ -11,5 +13,6 @@ public interface IScriptableNpc : IScriptable
 
     void Say(string message);
     void SayLocalized(int stringId);
-    void MoveTo(float x, float y, float z, bool direct);
+    IAction MoveTo(float x, float y, float z, bool direct);
+    void SetAction(string slot, IAction action);
 }

--- a/src/Sanctuary.Scripting/NpcUserData.cs
+++ b/src/Sanctuary.Scripting/NpcUserData.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 using Lua;
+
+using Sanctuary.Core.Actions;
 
 namespace Sanctuary.Scripting;
 
@@ -51,10 +54,75 @@ internal sealed class NpcUserData(IScriptableNpc npc) : ILuaUserData
             direct = context.GetArgument<bool>(4);
         }
 
-        self._npc.MoveTo(x, y, z, direct);
+        // MoveTo just constructs the action now - pair it with SetAction here so the simple
+        // "fire and forget" Lua call still starts moving immediately, same as before.
+        self._npc.SetAction("move", self._npc.MoveTo(x, y, z, direct));
 
         return new ValueTask<int>(context.Return());
     });
+
+    // Supported step keys: "say" (InstantAction), "wait" (seconds), "moveTo" (real MoveToAction,
+    // reports done only once actually arrived), "parallel"/"sequential" (nested step lists).
+    // NOTE: no "anim"/"reward" steps yet - those C# capabilities don't exist on Npc at all yet.
+    private static readonly LuaFunction RunBehaviorFunction = new("runBehavior", static (context, cancellationToken) =>
+    {
+        var self = context.GetArgument<NpcUserData>(0);
+        var slot = context.GetArgument<string>(1);
+        var step = context.GetArgument<LuaTable>(2);
+
+        var action = ParseStep(self._npc, step);
+        self._npc.SetAction(slot, action);
+
+        return new ValueTask<int>(context.Return());
+    });
+
+    private static IAction ParseSequence(IScriptableNpc npc, LuaTable steps)
+    {
+        return new SequentialAction(ParseSteps(npc, steps));
+    }
+
+    private static IAction[] ParseSteps(IScriptableNpc npc, LuaTable steps)
+    {
+        var result = new IAction[steps.ArrayLength];
+
+        for (var i = 0; i < steps.ArrayLength; i++)
+            result[i] = ParseStep(npc, steps[(double)(i + 1)].Read<LuaTable>());
+
+        return result;
+    }
+
+    private static IAction ParseStep(IScriptableNpc npc, LuaTable step)
+    {
+        var say = step["say"];
+        if (say.Type != LuaValueType.Nil)
+            return new InstantAction(() => npc.Say(say.Read<string>()));
+
+        var wait = step["wait"];
+        if (wait.Type != LuaValueType.Nil)
+            return new WaitAction(wait.Read<double>());
+
+        var moveTo = step["moveTo"];
+        if (moveTo.Type == LuaValueType.Table)
+        {
+            var position = moveTo.Read<LuaTable>();
+            var x = position[1.0].Read<float>();
+            var y = position[2.0].Read<float>();
+            var z = position[3.0].Read<float>();
+            var direct = position.ArrayLength >= 4 && position[4.0].Read<bool>();
+
+            return npc.MoveTo(x, y, z, direct);
+        }
+
+        var parallel = step["parallel"];
+        if (parallel.Type == LuaValueType.Table)
+            return new ParallelAction(ParseSteps(npc, parallel.Read<LuaTable>()));
+
+        var sequential = step["sequential"];
+        if (sequential.Type == LuaValueType.Table)
+            return ParseSequence(npc, sequential.Read<LuaTable>());
+
+        throw new InvalidOperationException("Unrecognized behavior step");
+    }
 
     #endregion
 
@@ -85,6 +153,7 @@ internal sealed class NpcUserData(IScriptableNpc npc) : ILuaUserData
                 "say" => SayFunction,
                 "sayLocalized" => SayLocalizedFunction,
                 "moveTo" => MoveToFunction,
+                "runBehavior" => RunBehaviorFunction,
                 _ => LuaValue.Nil
             };
 


### PR DESCRIPTION
Please read...

The purpose of this PR is to prototype an interface between the `lua` layer and `C#` layer for NPC behavior. I'm not fully happy with it, but in case it shows potential, I want to have this up. I _do not_ expect this to go through, but I'm just listing some considerations I've been making about NPCs and how they might behave.

# Actions
Why? Some NPC behaviors are instant (i.e., saying something or dropping a reward), while others may need to run on the tick (or per second) loop (e.g., movement, waiting). An action tries to unify this. Each action would have the following:

1) `void OnStart`: called when the action is first started (great for setting things up once)
2) `bool OnTick`: called every tick, returns `true` when considered complete

This way, something like `lua` simply needs to construct a behavior (or set of behaviors) and pass it through. Everything will be stepped `OnTick`, so nothing should be blocking the process.

## Managing actions
The `ActionManager` keeps a dictionary of string keys to actions and updates every tick. When an action completes, it is removed from the dictionary (and thus, doesn't run). If one needed to interrupt an action (e.g., the NPC is moving towards the player, but something triggers asking it to retreat), one can simply replace the value in the dictionary for a given key. 

## Action types
1) `InstantAction`: performs some function and immediately returns `true`
2) `TimeoutAction`: performs an action with a timeout that will return `true`
3) `WaitAction`: non-blocking action used for waiting some amount of time
4) `SequentialAction`: runs things one-by-one, then returns `true` when complete
5) `ParallelAction`: runs actions in parallel (i.e., each `OnTick` step is done on the same tick, this is _not_ true parallelism), then returns `true` when all are done

A `DelegateAction` can be used to define more custom behavior. For example, a `MoveToAction` can be built this way for NPCs to move.

## Future action types
In the interest of saving time, I have yet to implement other potentially (?) useful types of actions:
1) `RepeatAction`: Repeat a given action multiple times (or infinitely until interrupted) 
2) `WaitUntilAction`: Wait until a given condition is met, then perform the action
3) `DoUntilAction`: Perform an action until a given condition is met.
 
## References
1) https://docs.wpilib.org/en/stable/docs/software/commandbased/commands.html
2) https://rr.brott.dev/docs/v1-0/actions/
