### PR TITLE
Fix memory leak due to orphaned Player references in NPC visibility lists

### DIFF
--- a/src/Sanctuary.Game/Entities/Player.cs
+++ b/src/Sanctuary.Game/Entities/Player.cs
@@ -223,12 +223,7 @@ public sealed class Player : ClientPcData, IEntity
         if (Mount is not null)
             Mount.TeleportToZone(zone, position, rotation);
 
-        // Alert/Remove visible entities
-        foreach (var visiblePlayer in VisiblePlayers)
-            visiblePlayer.Value.OnRemoveVisiblePlayers([this]);
-
-        OnRemoveVisibleNpcs(VisibleNpcs.Values);
-        OnRemoveVisiblePlayers(VisiblePlayers.Values);
+        RemoveFromVisibleEntities();
 
         ZoneTile.Entities.Remove(Guid, out _);
 
@@ -629,10 +624,21 @@ public sealed class Player : ClientPcData, IEntity
 
     #endregion
 
-    public void Dispose()
+    private void RemoveFromVisibleEntities()
     {
+        foreach (var visibleNpc in VisibleNpcs)
+            visibleNpc.Value.OnRemoveVisiblePlayers([this]);
+
         foreach (var visiblePlayer in VisiblePlayers)
             visiblePlayer.Value.OnRemoveVisiblePlayers([this]);
+
+        OnRemoveVisibleNpcs(VisibleNpcs.Values);
+        OnRemoveVisiblePlayers(VisiblePlayers.Values);
+    }
+
+    public void Dispose()
+    {
+        RemoveFromVisibleEntities();
 
         Mount?.Dispose();
         Mount = null;

--- a/src/Sanctuary.Game/Entities/Player.cs
+++ b/src/Sanctuary.Game/Entities/Player.cs
@@ -223,7 +223,7 @@ public sealed class Player : ClientPcData, IEntity
         if (Mount is not null)
             Mount.TeleportToZone(zone, position, rotation);
 
-        RemoveFromVisibleEntities();
+        RemoveFromVisibleEntities(true);
 
         ZoneTile.Entities.Remove(Guid, out _);
 
@@ -624,7 +624,7 @@ public sealed class Player : ClientPcData, IEntity
 
     #endregion
 
-    private void RemoveFromVisibleEntities()
+    private void RemoveFromVisibleEntities(bool notifySelf)
     {
         foreach (var visibleNpc in VisibleNpcs)
             visibleNpc.Value.OnRemoveVisiblePlayers([this]);
@@ -632,13 +632,16 @@ public sealed class Player : ClientPcData, IEntity
         foreach (var visiblePlayer in VisiblePlayers)
             visiblePlayer.Value.OnRemoveVisiblePlayers([this]);
 
-        OnRemoveVisibleNpcs(VisibleNpcs.Values);
-        OnRemoveVisiblePlayers(VisiblePlayers.Values);
+        if (notifySelf)
+        {
+            OnRemoveVisibleNpcs(VisibleNpcs.Values);
+            OnRemoveVisiblePlayers(VisiblePlayers.Values);
+        }
     }
 
     public void Dispose()
     {
-        RemoveFromVisibleEntities();
+        RemoveFromVisibleEntities(false); // no need to notify self since we're DCing
 
         Mount?.Dispose();
         Mount = null;


### PR DESCRIPTION
htop showed the gateway container using 40% of the public server RAM (almost 4GB!) three days after a full server hang due to OOM. With only 60 players on at the time, it didn't make any sense.

I collected a full memory dump and discovered hundreds of Player objects (and all the network plumbing associated with them) still in memory, which is way more than 60. I took a look around and noticed that although we remove the player from other player's visibility lists on dispose, **we do not remove them from NPC visibility lists.** Since we have hundreds of NPCs that never despawn, this kept the player objects from being GC'd even after disconnect. I couldn't find any other path that would explain the leak.

This change covers the NPC visibility lists too and hoists it all into a helper that is also called on zone TP aside from dispose to keep this logic in one place.