### PR TITLE
Clear the toolbar when a combat job has no weapon equipped

### DIFF
--- a/src/Sanctuary.Game/Entities/Player.cs
+++ b/src/Sanctuary.Game/Entities/Player.cs
@@ -790,25 +790,25 @@ public sealed class Player : ClientPcData, IEntity
             return false;
         }
 
-        var weaponDefinitionId = GetEquippedWeaponDefinitionId();
-        var (basic, special) = ResolveWeaponAbilities(kit, weaponDefinitionId);
-
-        var weaponNameId = 0;
-        if (_resourceManager.ClientItemDefinitions.TryGetValue(weaponDefinitionId, out var weaponDefinition))
-            weaponNameId = weaponDefinition.NameId;
-
         var setDefinition = new AbilityPacketSetDefinition { ProfileId = kit.ProfileId };
 
-        if (basic is not null)
-        {
-            setDefinition.AbilitySet.Abilities[0] = CreateToolbarSlot(kit.BasicSlotDefId, basic.IconId, weaponNameId, manaCost: 0);
-            SendAbilityDefinition(kit.BasicSlotDefId, basic);
-        }
+        var weaponDefinitionId = GetEquippedWeaponDefinitionId();
 
-        if (special is not null)
+        if (_resourceManager.ClientItemDefinitions.TryGetValue(weaponDefinitionId, out var weaponDefinition))
         {
-            setDefinition.AbilitySet.Abilities[1] = CreateToolbarSlot(kit.SpecialSlotDefId, special.IconId, weaponNameId, special.EnergyCost);
-            SendAbilityDefinition(kit.SpecialSlotDefId, special);
+            var (basic, special) = ResolveWeaponAbilities(kit, weaponDefinitionId);
+
+            if (basic is not null)
+            {
+                setDefinition.AbilitySet.Abilities[0] = CreateToolbarSlot(kit.BasicSlotDefId, basic.IconId, weaponDefinition.NameId, manaCost: 0);
+                SendAbilityDefinition(kit.BasicSlotDefId, basic);
+            }
+
+            if (special is not null)
+            {
+                setDefinition.AbilitySet.Abilities[1] = CreateToolbarSlot(kit.SpecialSlotDefId, special.IconId, weaponDefinition.NameId, special.EnergyCost);
+                SendAbilityDefinition(kit.SpecialSlotDefId, special);
+            }
         }
 
         SendTunneled(setDefinition);
@@ -847,9 +847,7 @@ public sealed class Player : ClientPcData, IEntity
 
     private (AbilityDefinition? Basic, AbilityDefinition? Special) ResolveWeaponAbilities(JobKitDefinition kit, int weaponDefinitionId)
     {
-        var mapping = weaponDefinitionId != 0
-            ? kit.Weapons.FirstOrDefault(w => w.WeaponDefIds.Contains(weaponDefinitionId))
-            : null;
+        var mapping = kit.Weapons.FirstOrDefault(w => w.WeaponDefIds.Contains(weaponDefinitionId));
 
         var basicId = mapping?.BasicAbilityId ?? kit.FallbackBasicAbilityId;
         var specialId = mapping?.SpecialAbilityId ?? 0;


### PR DESCRIPTION
Switching to a combat job with nothing in the weapon slot kept the previous job's toolbar on screen. The slots were being sent with the kit fallback ability but no weapon NameId, and the client skips drawing nameless slots without clearing the old ones.

Now the toolbar only populates when an equipped weapon with a known item definition exists; otherwise the empty set is sent, which clears the bar the same way the non-combat path already does. This also covers unequipping your weapon while on a combat job.

Play-tested: wizard with weapon → weaponless ninja now shows an empty bar; equipping a ninja weapon populates it; non-combat switch still clears.